### PR TITLE
Re-uses a single context in docking_on_gpu

### DIFF
--- a/cuda/GpuData.h
+++ b/cuda/GpuData.h
@@ -95,6 +95,17 @@ struct GpuData {
     unsigned int                    warpmask;
     unsigned int                    warpbits;
 };
+
+struct GpuTempData {
+    float*      pMem_fgrids;
+    float*      pMem_conformations1;
+    float*      pMem_conformations2;
+    float*      pMem_energies1;
+    float*      pMem_energies2;
+    int*        pMem_evals_of_new_entities;
+    int*        pMem_gpu_evals_of_runs;
+    uint32_t*   pMem_prng_states;
+};
 #endif
 
 

--- a/host/inc/performdocking.h
+++ b/host/inc/performdocking.h
@@ -66,6 +66,10 @@ typedef struct {
 } Gradientparameters;
 #endif
 
+void setup_gpu_for_docking(GpuData& cData, 
+                           GpuTempData& tData);
+void finish_gpu_from_docking(GpuData& cData, 
+                             GpuTempData& tData);
 int docking_with_gpu(const Gridinfo* 		mygrid,
          	     /*const*/ float* 		cpu_floatgrids,
 		           Dockpars*		mypars,
@@ -74,7 +78,9 @@ int docking_with_gpu(const Gridinfo* 		mygrid,
                         Profile&                profile,
 		     const int* 		argc,
 		     char**			argv,
-			SimulationState&	sim_state);
+			SimulationState&	sim_state,
+			GpuData& cData,
+			GpuTempData& tData);
 
 double check_progress(int* evals_of_runs,
 		      int generation_cnt,


### PR DESCRIPTION
This change moves the memory allocation, freeing, and most of the memcpy's from docking_on_gpu to routines that allow for the reuse of a single context. There may be further optimizations possible. 