### PR TITLE
WIP Patch to read grids from file only once - DO NOT MERGE YET

### DIFF
--- a/host/inc/performdocking.h
+++ b/host/inc/performdocking.h
@@ -66,8 +66,12 @@ typedef struct {
 } Gradientparameters;
 #endif
 
+// Clears all GPU memory held in place by caching grids on the GPU.
+void clear_gpu();
+// Allocates space for GPU constants and copies what can be copied.
 void setup_gpu_for_docking(GpuData& cData, 
                            GpuTempData& tData);
+// Frees GPU memory allocated in setup_gpu_for_docking.
 void finish_gpu_from_docking(GpuData& cData, 
                              GpuTempData& tData);
 int docking_with_gpu(const Gridinfo* 		mygrid,

--- a/host/inc/processgrid.h
+++ b/host/inc/processgrid.h
@@ -81,7 +81,7 @@ typedef struct
 int get_gridinfo(const char*, Gridinfo*);
 
 int get_gridvalues_f(const Gridinfo* mygrid,
-		     float* fgrids,
+		     float** fgrids,
 		     bool cgmaps);
 
 #endif /* PROCESSGRID_H_ */

--- a/host/inc/processgrid.h
+++ b/host/inc/processgrid.h
@@ -66,8 +66,10 @@ typedef struct
 
 #ifndef _WIN32
 	char*  grid_file_path;	  // Added to store the full path of the grid file
+	char*  grid_file_dir;	  // Added to store the full dir of the grid file
 #else
 	char  grid_file_path[2*_MAX_DIR];	  // Added to store the full path of the grid file
+	char  grid_file_dir[2*_MAX_DIR];	  // Added to store the full dir of the grid file
 #endif
 	char   receptor_name [64];
 	int    size_xyz [3];

--- a/host/inc/processgrid.h
+++ b/host/inc/processgrid.h
@@ -84,4 +84,8 @@ int get_gridvalues_f(const Gridinfo* mygrid,
 		     float** fgrids,
 		     bool cgmaps);
 
+// This will release the resources used by get_gridinfo and get_gridvalues_f
+// to cache files.
+void release_grids();
+
 #endif /* PROCESSGRID_H_ */

--- a/host/inc/setup.hpp
+++ b/host/inc/setup.hpp
@@ -39,7 +39,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 int setup(Gridinfo&		mygrid,
-	  std::vector<float>& floatgrids,
+	  //std::vector<float>& floatgrids,
+	  float**              floatgrids,
 	  Dockpars&		mypars,
 	  Liganddata&		myligand_init,
 	  Liganddata&		myxrayligand,

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -142,8 +142,8 @@ int main(int argc, char* argv[])
 	{
 	int t_id = 0;
 #endif
-    if(t_id!=execution_thread || nthreads==1) { // This thread handles setup and processing
-	setup_gpu_for_docking(cData,tData);
+    if(t_id==execution_thread) { // This thread handles setup and processing
+	  setup_gpu_for_docking(cData,tData);
 	}
 	while (!finished_all){
 		if(t_id!=execution_thread || nthreads==1) { // This thread handles setup and processing
@@ -250,8 +250,8 @@ int main(int argc, char* argv[])
 		}
 		if (n_finished_jobs==n_files) finished_all=true;
 	} // end of while loop
-    if(t_id!=execution_thread || nthreads==1) { // This thread handles setup and processing
-	finish_gpu_from_docking(cData,tData);
+    if(t_id==execution_thread) { // This thread handles setup and processing
+	  finish_gpu_from_docking(cData,tData);
 	}
 	} // end of parallel section
 

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -257,6 +257,8 @@ int main(int argc, char* argv[])
 	  finish_gpu_from_docking(cData,tData);
 	}
 	} // end of parallel section
+	clear_gpu();
+	release_grids();
 
 #ifndef _WIN32
 	// Total time measurement

--- a/host/src/performdocking.cpp
+++ b/host/src/performdocking.cpp
@@ -546,7 +546,6 @@ filled with clock() */
     cData.warpbits = 5;
 
     // Upload data
-	fprintf(stderr,"DEBUG: pMem_fgrids: %lx\n",tData.pMem_fgrids);
     status = cudaMemcpy(pMem_conformations_current, cpu_init_populations, size_populations, cudaMemcpyHostToDevice);
     RTERROR(status, "pMem_conformations_current: failed to upload to GPU memory.\n"); 
     status = cudaMemcpy(tData.pMem_gpu_evals_of_runs, sim_state.cpu_evals_of_runs.data(), size_evals_of_runs, cudaMemcpyHostToDevice);

--- a/host/src/performdocking.cpp
+++ b/host/src/performdocking.cpp
@@ -515,7 +515,7 @@ filled with clock() */
 		// It makes no attempt to choose the memory intelligently. 
 		if ( status == cudaErrorMemoryAllocation )
 		{ // Free memory from GPU cache and try again
-          for ( auto iter = present_table.begin; iter < present_table.end; iter++)
+          for ( auto iter = present_table.begin(); iter != present_table.end(); iter++)
 		  {
 			  cudaFree(iter->second);
 			  present_table.erase(iter);

--- a/host/src/performdocking.cpp
+++ b/host/src/performdocking.cpp
@@ -77,12 +77,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #define OPT_PROG INC KNWI REP KGDB
 
 #include <vector>
+#include <map>
 
 #include "autostop.hpp"
 #include "performdocking.h"
 #include "correct_grad_axisangle.h"
 #include "GpuData.h"
 
+// Maintains a mapping of a CPU array to a matching array on the GPU.
+std::map<float*,float*> present_table;
 
 // CUDA kernels
 void SetKernelsGpuData(GpuData* pData);
@@ -222,9 +225,9 @@ void setup_gpu_for_docking(GpuData& cData, GpuTempData& tData)
     RTERROR(status, "cData.pMem_dependence_on_rotangle_const: failed to upload to GPU memory.\n");       
 
 	// Allocate temporary data - JL TODO - Are these sizes correct?
-	size_t size_floatgrids = 4 * (sizeof(float)) * (MAX_NUM_OF_ATYPES+2) * (MAX_NUM_GRIDPOINTS) * (MAX_NUM_GRIDPOINTS) * (MAX_NUM_GRIDPOINTS);    
-    status = cudaMalloc((void**)&(tData.pMem_fgrids), size_floatgrids);
-    RTERROR(status, "pMem_fgrids: failed to allocate GPU memory.\n");
+	//size_t size_floatgrids = 4 * (sizeof(float)) * (MAX_NUM_OF_ATYPES+2) * (MAX_NUM_GRIDPOINTS) * (MAX_NUM_GRIDPOINTS) * (MAX_NUM_GRIDPOINTS);    
+    //status = cudaMalloc((void**)&(tData.pMem_fgrids), size_floatgrids);
+    //RTERROR(status, "pMem_fgrids: failed to allocate GPU memory.\n");
 	size_t size_populations = MAX_NUM_OF_RUNS * MAX_POPSIZE * GENOTYPE_LENGTH_IN_GLOBMEM*sizeof(float);
     status = cudaMalloc((void**)&(tData.pMem_conformations1), size_populations);
     RTERROR(status, "pMem_conformations1: failed to allocate GPU memory.\n");   
@@ -274,8 +277,8 @@ void finish_gpu_from_docking(GpuData& cData, GpuTempData& tData)
     RTERROR(status, "cudaFree: error freeing cData.pMem_dependence_on_rotangle_const");  
     
     // Non-constant
-    status = cudaFree(tData.pMem_fgrids);
-    RTERROR(status, "cudaFree: error freeing pMem_fgrids");
+    //status = cudaFree(tData.pMem_fgrids);
+    //RTERROR(status, "cudaFree: error freeing pMem_fgrids");
     status = cudaFree(tData.pMem_conformations1);
     RTERROR(status, "cudaFree: error freeing pMem_conformations1");
     status = cudaFree(tData.pMem_conformations2);
@@ -492,6 +495,24 @@ filled with clock() */
     float* pMem_energies_current = tData.pMem_energies1;
     float* pMem_energies_next = tData.pMem_energies2;
     
+	// Check whether there's already a copy of cpu_floatgrids on the GPU. If so,
+	// reuse the existing copy. If not, allocate space and copy it. 
+	auto search = present_table.find(cpu_floatgrids);
+	if ( search == present_table.end() )
+	{
+		//fprintf(stderr, "\nDEBUG: floatgrids not on GPU yet\n");
+        status = cudaMalloc((void**)&(tData.pMem_fgrids), size_floatgrids);
+        RTERROR(status, "pMem_fgrids: failed to allocate GPU memory.\n");
+		
+        status = cudaMemcpy(tData.pMem_fgrids, cpu_floatgrids, size_floatgrids, cudaMemcpyHostToDevice);
+        RTERROR(status, "pMem_fgrids: failed to upload to GPU memory.\n"); 
+		present_table.insert({cpu_floatgrids,tData.pMem_fgrids});
+	} else
+	{
+		//fprintf(stderr, "\nDEBUG: Reusing pMem_fgrids on GPU.\n");
+        tData.pMem_fgrids = search->second;
+	}
+
     // Set constant pointers
     cData.pMem_fgrids = tData.pMem_fgrids;
     cData.pMem_evals_of_new_entities = tData.pMem_evals_of_new_entities;
@@ -503,8 +524,7 @@ filled with clock() */
     cData.warpbits = 5;
 
     // Upload data
-    status = cudaMemcpy(tData.pMem_fgrids, cpu_floatgrids, size_floatgrids, cudaMemcpyHostToDevice);
-    RTERROR(status, "pMem_fgrids: failed to upload to GPU memory.\n"); 
+	fprintf(stderr,"DEBUG: pMem_fgrids: %lx\n",tData.pMem_fgrids);
     status = cudaMemcpy(pMem_conformations_current, cpu_init_populations, size_populations, cudaMemcpyHostToDevice);
     RTERROR(status, "pMem_conformations_current: failed to upload to GPU memory.\n"); 
     status = cudaMemcpy(tData.pMem_gpu_evals_of_runs, sim_state.cpu_evals_of_runs.data(), size_evals_of_runs, cudaMemcpyHostToDevice);

--- a/host/src/performdocking.cpp
+++ b/host/src/performdocking.cpp
@@ -147,6 +147,15 @@ inline float stddev(float* average_sd2_N)
 	return sqrt(sq)/average_sd2_N[2];
 }
 
+// Clears all GPU memory held in place by caching grids on the GPU.
+void clear_gpu()
+{
+	for (auto grid = present_table.begin(); grid != present_table.end(); grid++)
+	{
+		cudaFree(grid->second);
+	}
+	present_table.clear();
+}
 void setup_gpu_for_docking(GpuData& cData, GpuTempData& tData)
 {
     auto const t0 = std::chrono::steady_clock::now();

--- a/host/src/processgrid.cpp
+++ b/host/src/processgrid.cpp
@@ -248,3 +248,16 @@ int get_gridvalues_f(const Gridinfo* mygrid, float** fgrids, bool cgmaps)
 	return 0;
 }
 
+// This will release the resources used by get_gridinfo and get_gridvalues_f
+// to cache files.
+void release_grids()
+{
+	for (auto grid = masterGrids.begin(); grid != masterGrids.end(); grid++)
+	{
+		// This will likely be cleaned up already due to moving into the
+		// map, but cleaning up memory to be sure.
+        grid->second.second.clear();
+	}
+	masterGrids.clear();
+}
+

--- a/host/src/processgrid.cpp
+++ b/host/src/processgrid.cpp
@@ -51,7 +51,8 @@ int get_gridinfo(const char* fldfilename, Gridinfo* mygrid)
 
 	#ifndef _WIN32
 	char* ts1 = strdup(fldfilename);
-	mygrid->grid_file_path = dirname(ts1);
+	mygrid->grid_file_dir= dirname(ts1);
+	mygrid->grid_file_path = strdup(fldfilename);
 	#else
 	char* ts1 = strdup(fldfilename);
 	char drive_tmp[_MAX_DRIVE];
@@ -62,8 +63,9 @@ int get_gridinfo(const char* fldfilename, Gridinfo* mygrid)
 	strcpy(result, drive_tmp);
 	strcpy(result, path_tmp);
 	for (unsigned int i=0; i<2*_MAX_DIR; i++) {
-		mygrid->grid_file_path[i] = result[i];
+		mygrid->grid_file_dir[i] = result[i];
 	}
+	strncpy(mygrid->grid_file_path, fldfilename, 2*_MAX_DIR);
 	#endif
 	// ----------------------------------------------------
 
@@ -185,7 +187,7 @@ int get_gridvalues_f(const Gridinfo* mygrid, float** fgrids, bool cgmaps)
 	  	//opening corresponding .map file
 	  	//-------------------------------------
 	  	// Added the complete path of associated grid files.
-	  	strcpy(tempstr,mygrid->grid_file_path);
+	  	strcpy(tempstr,mygrid->grid_file_dir);
 	  	strcat(tempstr, "/");
 	  	strcat(tempstr, mygrid->receptor_name);
 	  	

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -35,7 +35,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "setup.hpp"
 
 int setup(Gridinfo&            mygrid,
-	  std::vector<float>& floatgrids,
+	  //std::vector<float>& floatgrids,
+	  float**              floatgrids,
 	  Dockpars&            mypars,
 	  Liganddata&          myligand_init,
 	  Liganddata&          myxrayligand,
@@ -93,10 +94,10 @@ int setup(Gridinfo&            mygrid,
 		{printf("\n\nError in get_liganddata, stopped job."); return 1;}
 
 	// Resize grid
-	floatgrids.resize(4*(mygrid.num_of_atypes+2)*mygrid.size_xyz[0]*mygrid.size_xyz[1]*mygrid.size_xyz[2]);
+	//floatgrids.resize(4*(mygrid.num_of_atypes+2)*mygrid.size_xyz[0]*mygrid.size_xyz[1]*mygrid.size_xyz[2]);
 
 	//Reading the grid files and storing values in the memory region pointed by floatgrids
-	if (get_gridvalues_f(&mygrid, floatgrids.data(), mypars.cgmaps) != 0)
+	if (get_gridvalues_f(&mygrid, floatgrids, mypars.cgmaps) != 0)
 		{printf("\n\nError in get_gridvalues_f, stopped job."); return 1;}
 
 	//------------------------------------------------------------
@@ -128,7 +129,7 @@ int setup(Gridinfo&            mygrid,
 		print_ref_lig_energies_f(myligand_init,
 					 mypars.smooth,
 					 mygrid,
-					 floatgrids.data(),
+					 *floatgrids,
 					 mypars.coeffs.scaled_AD4_coeff_elec,
 					 mypars.coeffs.AD4_coeff_desolv,
 					 mypars.qasp);


### PR DESCRIPTION
This patch modifies the reading of grids from files to only read the file one. It also modifies the docking routine to only allocate data on the GPU and copy each grid once. 

Still needs more extensive error checking. Does not (and likely will not) handle OOM error.