### PR TITLE
Skip ligand if atom distances are 0

### DIFF
--- a/LICENSE_LGPL
+++ b/LICENSE_LGPL
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,8 @@ endif
 # FDEBUG (full) : enables debugging on both host + device
 # LDEBUG (light): enables debugging on host
 # RELEASE
-#CONFIG=RELEASE
-CONFIG=FDEBUG
+CONFIG=RELEASE
+#CONFIG=FDEBUG
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ else ifeq ($(DEVICE), GPU)
 	TARGET:=$(TARGET)_gpu
 endif
 
+ifeq ($(OVERLAP), ON)
+	PIPELINE=-DUSE_PIPELINE -fopenmp
+endif
+
+
 BIN := $(wildcard $(TARGET)*)
 
 # ------------------------------------------------------
@@ -197,7 +202,7 @@ odock: check-env-all kernels $(SRC)
 	$(CFLAGS) \
 	$(LIB_CUDA) \
 	-o$(BIN_DIR)/$(TARGET) \
-	$(DEV) $(NWI) $(OPT) $(DD) $(REP) $(KFLAGS)
+	$(DEV) $(NWI) $(PIPELINE) $(OPT) $(DD) $(REP) $(KFLAGS)
 
 # Example
 # 1ac8: for testing gradients of translation and rotation genes

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ CFLAGS+=-DVERSION=\"$(GIT_VERSION)\"
 # ------------------------------------------------------
 
 kernels: $(KERNEL_SRC)
-	$(NVCC) $(NWI) $(CUDA_FLAGS) $(IFLAGS) $(CUDA_INCLUDES) -c $(KRNL_DIR)/kernels.cu
+	$(NVCC) $(NWI) $(REP) $(CUDA_FLAGS) $(IFLAGS) $(CUDA_INCLUDES) -c $(KRNL_DIR)/kernels.cu
 
 odock: check-env-all kernels $(SRC)
 	$(CPP) \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ HOST_SRC_DIR=./host/src
 KRNL_DIR=./cuda
 KCMN_DIR=$(COMMON_DIR)
 BIN_DIR=./bin
-CUDA_FLAGS = -use_fast_math --ptxas-options="-v" -gencode arch=compute_70,code=sm_70 -std=c++11
 LIB_CUDA = kernels.o -lcurand -lcudart 
 
 
@@ -103,19 +102,23 @@ endif
 # FDEBUG (full) : enables debugging on both host + device
 # LDEBUG (light): enables debugging on host
 # RELEASE
-CONFIG=RELEASE
-#CONFIG=FDEBUG
+#CONFIG=RELEASE
+CONFIG=FDEBUG
 
 
 
 ifeq ($(CONFIG),FDEBUG)
 	OPT =-O0 -g3 -Wall -DDOCK_DEBUG
+    CUDA_FLAGS = -g -use_fast_math --ptxas-options="-v" -gencode arch=compute_75,code=sm_75 -std=c++11	
 else ifeq ($(CONFIG),LDEBUG)
 	OPT =-O0 -g3 -Wall 
+	CUDA_FLAGS = -use_fast_math --ptxas-options="-v" -gencode arch=compute_75,code=sm_75 -std=c++11	
 else ifeq ($(CONFIG),RELEASE)
 	OPT =-O3
+	CUDA_FLAGS = -use_fast_math --ptxas-options="-v" -gencode arch=compute_75,code=sm_75 -std=c++11
 else
 	OPT =
+    CUDA_FLAGS = -use_fast_math --ptxas-options="-v" -gencode arch=compute_75,code=sm_75 -std=c++11	
 endif
 
 # ------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -109,16 +109,16 @@ CONFIG=FDEBUG
 
 ifeq ($(CONFIG),FDEBUG)
 	OPT =-O0 -g3 -Wall -DDOCK_DEBUG
-    CUDA_FLAGS = -g -use_fast_math --ptxas-options="-v" -gencode arch=compute_75,code=sm_75 -std=c++11	
+    CUDA_FLAGS = -G -use_fast_math --ptxas-options="-v" -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -std=c++11	
 else ifeq ($(CONFIG),LDEBUG)
 	OPT =-O0 -g3 -Wall 
-	CUDA_FLAGS = -use_fast_math --ptxas-options="-v" -gencode arch=compute_75,code=sm_75 -std=c++11	
+	CUDA_FLAGS = -use_fast_math --ptxas-options="-v" -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -std=c++11	
 else ifeq ($(CONFIG),RELEASE)
 	OPT =-O3
-	CUDA_FLAGS = -use_fast_math --ptxas-options="-v" -gencode arch=compute_75,code=sm_75 -std=c++11
+	CUDA_FLAGS = -use_fast_math --ptxas-options="-v" -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -std=c++11
 else
 	OPT =
-    CUDA_FLAGS = -use_fast_math --ptxas-options="-v" -gencode arch=compute_75,code=sm_75 -std=c++11	
+    CUDA_FLAGS = -use_fast_math --ptxas-options="-v" -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -std=c++11	
 endif
 
 # ------------------------------------------------------

--- a/add_selective_preamble_license.sh
+++ b/add_selective_preamble_license.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copy license preamble to all AutoDock-GPU source and header files
+# if license preamble is not present
+
+# license preamble
+LICENSE_PREAMBLE="./preamble_license"
+LICENSE_PREAMBLE_LGPL="./preamble_license_lgpl"
+
+# kernel-header files
+KRNL_HEADER_DIR="./common"
+KRNL_HEADERS="$KRNL_HEADER_DIR/*.h"
+
+# kernel-source files
+KRNL_SOURCE_DIR="./device"
+KRNL_SOURCES="$KRNL_SOURCE_DIR/*.cl"
+
+# host-header files
+HOST_HEADER_DIR="./host/inc"
+HOST_HEADERS="$HOST_HEADER_DIR/calcenergy.h $HOST_HEADER_DIR/correct_grad_axisangle.h $HOST_HEADER_DIR/getparameters.h $HOST_HEADER_DIR/miscellaneous.h $HOST_HEADER_DIR/processgrid.h $HOST_HEADER_DIR/processligand.h $HOST_HEADER_DIR/processresult.h"
+HOST_HEADERS_LGPL="$HOST_HEADER_DIR/performdocking.h" 
+
+# host-source files
+HOST_SOURCE_DIR="./host/src"
+HOST_SOURCES="$HOST_SOURCE_DIR/calcenergy.cpp $HOST_SOURCE_DIR/getparameters.cpp $HOST_SOURCE_DIR/main.cpp $HOST_SOURCE_DIR/miscellaneous.cpp 		$HOST_SOURCE_DIR/processgrid.cpp $HOST_SOURCE_DIR/processligand.cpp $HOST_SOURCE_DIR/processresult.cpp"
+HOST_SOURCES_LGPL="$HOST_SOURCE_DIR/performdocking.cpp"
+
+# wrapcl-header files
+WRAPCL_HEADER_DIR="./wrapcl/inc"
+WRAPCL_HEADERS="$WRAPCL_HEADER_DIR/*.h"
+
+# wrapcl-source files
+WRAPCL_SOURCE_DIR="./wrapcl/src"
+WRAPCL_SOURCES="$WRAPCL_SOURCE_DIR/*.cpp"
+
+# full list of source files
+AUTODOCKGPU_SOURCE="$HOST_HEADERS $HOST_SOURCES $WRAPCL_HEADERS $WRAPCL_SOURCES"
+AUTODOCKGPU_SOURCE_LGPL="$HOST_HEADERS_LGPL $HOST_SOURCES_LGPL $KRNL_HEADERS $KRNL_SOURCES"
+
+# Add license-preamble
+# Excluding sources that already have it, and
+# excluding the automatically-generated ./host/inc/stringify.h
+for f in $AUTODOCKGPU_SOURCE; do
+	if [ "$f" != "$HOST_HEADER_DIR/stringify.h" ]; then
+
+		if (grep -q "Copyright (C)" $f); then
+			echo "License-preamble was found in $f"
+			echo "No license-preamble is added."
+		else
+			echo "Adding license-preamble to $f ..."
+			cat $LICENSE_PREAMBLE "$f" > "$f.new"
+			mv "$f.new" "$f"
+			echo "Done!"
+		fi
+		echo " "
+	fi
+done
+
+for f in $AUTODOCKGPU_SOURCE_LGPL; do
+	if [ "$f" != "$HOST_HEADER_DIR/stringify.h" ]; then
+
+		if (grep -q "Copyright (C)" $f); then
+			echo "License-preamble was found in $f"
+			echo "No license-preamble is added."
+		else
+			echo "Adding LGPL license-preamble to $f ..."
+			cat $LICENSE_PREAMBLE_LGPL "$f" > "$f.new"
+			mv "$f.new" "$f"
+			echo "Done!"
+		fi
+		echo " "
+	fi
+done

--- a/common/calcenergy_basic.h
+++ b/common/calcenergy_basic.h
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/common/defines.h
+++ b/common/defines.h
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/cuda/GpuData.h
+++ b/cuda/GpuData.h
@@ -65,6 +65,9 @@ typedef struct
         unsigned int    cons_limit;
         unsigned int    max_num_of_iters;
         float           qasp;
+        float           adam_beta1;
+        float           adam_beta2;
+        float           adam_epsilon;
 } GpuDockparameters;
 
 struct GpuData {

--- a/cuda/GpuData.h
+++ b/cuda/GpuData.h
@@ -95,6 +95,17 @@ struct GpuData {
     unsigned int                    warpmask;
     unsigned int                    warpbits;
 };
+
+struct GpuTempData {
+    float*      pMem_fgrids;
+    float*      pMem_conformations1;
+    float*      pMem_conformations2;
+    float*      pMem_energies1;
+    float*      pMem_energies2;
+    int*        pMem_evals_of_new_entities;
+    int*        pMem_gpu_evals_of_runs;
+    uint32_t*   pMem_prng_states;
+};
 #endif
 
 

--- a/cuda/GpuData.h
+++ b/cuda/GpuData.h
@@ -1,0 +1,98 @@
+#ifndef GPUDATADOTH
+#define GPUDATADOTH
+
+#define RTERROR(status, s) \
+    if (status != cudaSuccess) { \
+        printf("%s %s\n", s, cudaGetErrorString(status)); \
+        assert(0); \
+        cudaDeviceReset(); \
+        exit(-1); \
+    }
+    
+    
+#ifdef SYNCHRONOUS
+#define LAUNCHERROR(s) \
+    { \
+        cudaError_t status = cudaGetLastError(); \
+        if (status != cudaSuccess) { \
+            printf("Error: %s launching kernel %s\n", cudaGetErrorString(status), s); \
+            getGpu().Shutdown(); \
+            exit(-1); \
+        } \
+        cudaDeviceSynchronize(); \
+    }
+#else
+#define LAUNCHERROR(s) \
+    { \
+        cudaError_t status = cudaGetLastError(); \
+        if (status != cudaSuccess) { \
+            printf("Error: %s launching kernel %s\n", cudaGetErrorString(status), s); \
+            getGpu().Shutdown(); \
+            exit(-1); \
+        } \
+    }
+#endif
+
+typedef struct
+{
+        int             num_of_atoms;
+        int             num_of_atypes;
+        int             num_of_intraE_contributors;
+        int             gridsize_x;
+        int             gridsize_y;
+        int             gridsize_z;
+        int             gridsize_x_times_y;
+        int             gridsize_x_times_y_times_z;
+        float           grid_spacing;
+        float*          fgrids;
+        int             rotbondlist_length;
+        float           coeff_elec;
+        float           coeff_desolv;
+        int*            evals_of_new_entities;
+        unsigned int*   prng_states;
+        int             pop_size;
+        int             num_of_genes;
+        float           tournament_rate;
+        float           crossover_rate;
+        float           mutation_rate;
+        float           abs_max_dmov;
+        float           abs_max_dang;
+        float           lsearch_rate;
+        float           smooth;
+        unsigned int    num_of_lsentities;
+        float           rho_lower_bound;
+        float           base_dmov_mul_sqrt3;
+        float           base_dang_mul_sqrt3;
+        unsigned int    cons_limit;
+        unsigned int    max_num_of_iters;
+        float           qasp;
+} GpuDockparameters;
+
+struct GpuData {
+    GpuDockparameters               dockpars;
+    
+    // Consolidated constants and memory pointers to reduce kernel launch overhead
+    kernelconstant_interintra*      pKerconst_interintra;
+	kernelconstant_intracontrib*    pKerconst_intracontrib;
+	kernelconstant_intra*	        pKerconst_intra;
+	kernelconstant_rotlist*		    pKerconst_rotlist;
+	kernelconstant_conform*		    pKerconst_conform;
+	kernelconstant_grads*		    pKerconst_grads;
+    float*                          pMem_fgrids;
+    int*                            pMem_evals_of_new_entities;
+    int*                            pMem_gpu_evals_of_runs;
+    uint32_t*                       pMem_prng_states;
+    int                             mem_rotbonds_const[2*MAX_NUM_OF_ROTBONDS];
+    int                             mem_rotbonds_atoms_const[MAX_NUM_OF_ATOMS*MAX_NUM_OF_ROTBONDS];
+    int                             mem_num_rotating_atoms_per_rotbond_const[MAX_NUM_OF_ROTBONDS];
+    float                           mem_angle_const[1000];
+    float                           mem_dependence_on_theta_const[1000];
+    float                           mem_dependence_on_rotangle_const[1000];
+    
+    // CUDA-specific constants
+    unsigned int                    warpmask;
+    unsigned int                    warpbits;
+};
+#endif
+
+

--- a/cuda/GpuData.h
+++ b/cuda/GpuData.h
@@ -16,7 +16,7 @@
         cudaError_t status = cudaGetLastError(); \
         if (status != cudaSuccess) { \
             printf("Error: %s launching kernel %s\n", cudaGetErrorString(status), s); \
-            getGpu().Shutdown(); \
+            cudaDeviceReset(); \
             exit(-1); \
         } \
         cudaDeviceSynchronize(); \
@@ -27,7 +27,7 @@
         cudaError_t status = cudaGetLastError(); \
         if (status != cudaSuccess) { \
             printf("Error: %s launching kernel %s\n", cudaGetErrorString(status), s); \
-            getGpu().Shutdown(); \
+            cudaDeviceReset(); \
             exit(-1); \
         } \
     }

--- a/cuda/GpuData.h
+++ b/cuda/GpuData.h
@@ -49,7 +49,6 @@ typedef struct
         int             rotbondlist_length;
         float           coeff_elec;
         float           coeff_desolv;
-        int*            evals_of_new_entities;
         int             pop_size;
         int             num_of_genes;
         float           tournament_rate;

--- a/cuda/GpuData.h
+++ b/cuda/GpuData.h
@@ -9,7 +9,8 @@
         exit(-1); \
     }
     
-    
+
+#define SYNCHRONOUS    
 #ifdef SYNCHRONOUS
 #define LAUNCHERROR(s) \
     { \
@@ -19,7 +20,8 @@
             cudaDeviceReset(); \
             exit(-1); \
         } \
-        cudaDeviceSynchronize(); \
+        status = cudaDeviceSynchronize(); \
+        RTERROR(status, s); \
     }
 #else
 #define LAUNCHERROR(s) \
@@ -48,7 +50,6 @@ typedef struct
         float           coeff_elec;
         float           coeff_desolv;
         int*            evals_of_new_entities;
-        unsigned int*   prng_states;
         int             pop_size;
         int             num_of_genes;
         float           tournament_rate;

--- a/cuda/GpuData.h
+++ b/cuda/GpuData.h
@@ -44,7 +44,6 @@ typedef struct
         int             gridsize_x_times_y;
         int             gridsize_x_times_y_times_z;
         float           grid_spacing;
-        float*          fgrids;
         int             rotbondlist_length;
         float           coeff_elec;
         float           coeff_desolv;

--- a/cuda/GpuData.h
+++ b/cuda/GpuData.h
@@ -81,12 +81,12 @@ struct GpuData {
     int*                            pMem_evals_of_new_entities;
     int*                            pMem_gpu_evals_of_runs;
     uint32_t*                       pMem_prng_states;
-    int                             mem_rotbonds_const[2*MAX_NUM_OF_ROTBONDS];
-    int                             mem_rotbonds_atoms_const[MAX_NUM_OF_ATOMS*MAX_NUM_OF_ROTBONDS];
-    int                             mem_num_rotating_atoms_per_rotbond_const[MAX_NUM_OF_ROTBONDS];
-    float                           mem_angle_const[1000];
-    float                           mem_dependence_on_theta_const[1000];
-    float                           mem_dependence_on_rotangle_const[1000];
+    int*                            pMem_rotbonds_const;
+    int*                            pMem_rotbonds_atoms_const;
+    int*                            pMem_num_rotating_atoms_per_rotbond_const;
+    float*                          pMem_angle_const;
+    float*                          pMem_dependence_on_theta_const;
+    float*                          pMem_dependence_on_rotangle_const;
     
     // CUDA-specific constants
     unsigned int                    warpmask;

--- a/cuda/auxiliary_genetic.cu
+++ b/cuda/auxiliary_genetic.cu
@@ -1,0 +1,176 @@
+/*
+
+AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian Genetic Algorithm
+Copyright (C) 2017 TU Darmstadt, Embedded Systems and Applications Group, Germany. All rights reserved.
+For some of the code, Copyright (C) 2019 Computational Structural Biology Center, the Scripps Research Institute.
+
+AutoDock is a Trade Mark of the Scripps Research Institute.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+
+
+
+// -------------------------------------------------------
+//
+// -------------------------------------------------------
+inline __device__ uint32_t gpu_rand(
+    uint32_t* prng_states
+)
+//The GPU device function generates a random int
+//with a linear congruential generator.
+//Each thread (supposing num_of_runs*pop_size blocks and NUM_OF_THREADS_PER_BLOCK threads per block)
+//has its own state which is stored in the global memory area pointed by
+//prng_states (thread with ID tx in block with ID bx stores its state in prng_states[bx*NUM_OF_THREADS_PER_BLOCK+$
+//The random number generator uses the gcc linear congruential generator constants.
+{
+	uint state;
+
+#if defined (REPRO)
+	state = 1;
+#else
+  	// Current state of the threads own PRNG
+  	// state = prng_states[get_group_id(0)*NUM_OF_THREADS_PER_BLOCK + get_local_id(0)];
+	state = prng_states[blockIdx.x];
+
+	// Calculating next state
+  	state = (RAND_A*state+RAND_C);
+#endif
+  	// Saving next state to memory
+  	// prng_states[get_group_id(0)*NUM_OF_THREADS_PER_BLOCK + get_local_id(0)] = state;
+	prng_states[blockIdx.x] = state;
+
+  return state;
+}
+
+// -------------------------------------------------------
+//
+// -------------------------------------------------------
+inline __device__ float gpu_randf(
+		uint32_t* prng_states
+)
+//The GPU device function generates a
+//random float greater than (or equal to) 0 and less than 1.
+//It uses gpu_rand() function.
+{
+  	float state;
+
+	// State will be between 0 and 1
+#if defined (REPRO)
+	state = 0.55f;
+#else
+	state =  ((float)gpu_rand(prng_states) / (float)MAX_UINT)*0.999999f;
+#endif
+
+  return state;
+}
+
+// -------------------------------------------------------
+//
+// -------------------------------------------------------
+inline __device__ void map_angle(float& angle)
+// The GPU device function maps
+// the input parameter to the interval 0...360
+// (supposing that it is an angle).
+{
+	while (angle >= 360.0f) {
+		angle -= 360.0f;
+	}
+
+	while (angle < 0.0f) {
+		angle += 360.0f;
+	}
+}
+
+#if 0
+// -------------------------------------------------------
+//
+// -------------------------------------------------------
+void gpu_perform_elitist_selection(
+					     int    dockpars_pop_size,
+				    __global float* restrict dockpars_energies_current,
+				    __global float* restrict dockpars_energies_next,
+				    __global int*   restrict dockpars_evals_of_new_entities,
+					     int    dockpars_num_of_genes,
+				    __global float* restrict dockpars_conformations_next,
+		       		    __global const float* restrict dockpars_conformations_current,
+				    __local  float* best_energies,
+				    __local  int*   best_IDs,
+				    __local  int*   best_ID
+)
+//The GPU device function performs elitist selection,
+//that is, it looks for the best entity in conformations_current and
+//energies_current of the run that corresponds to the block ID,
+//and copies it to the place of the first entity in
+//conformations_next and energies_next.
+{
+	int entity_counter;
+	int gene_counter;
+	float best_energy;
+
+	if (get_local_id(0) < dockpars_pop_size) {
+		best_energies[get_local_id(0)] = dockpars_energies_current[get_group_id(0)+get_local_id(0)];
+		best_IDs[get_local_id(0)] = get_local_id(0);
+	}
+
+	for (entity_counter = NUM_OF_THREADS_PER_BLOCK+get_local_id(0);
+	     entity_counter < dockpars_pop_size;
+	     entity_counter+= NUM_OF_THREADS_PER_BLOCK) {
+
+	     if (dockpars_energies_current[get_group_id(0)+entity_counter] < best_energies[get_local_id(0)]) {
+		best_energies[get_local_id(0)] = dockpars_energies_current[get_group_id(0)+entity_counter];
+		best_IDs[get_local_id(0)] = entity_counter;
+	     }
+	}
+
+       barrier(CLK_LOCAL_MEM_FENCE);
+
+	// This could be implemented with a tree-like structure
+	// which may be slightly faster
+	if (get_local_id(0) == 0)
+	{
+		best_energy = best_energies[0];
+		best_ID[0] = best_IDs[0];
+
+		for (entity_counter = 1;
+		     entity_counter < NUM_OF_THREADS_PER_BLOCK;
+		     entity_counter++) {
+
+		     if ((best_energies[entity_counter] < best_energy) && (entity_counter < dockpars_pop_size)) {
+			      best_energy = best_energies[entity_counter];
+			      best_ID[0] = best_IDs[entity_counter];
+		     }
+		}
+
+		// Setting energy value of new entity
+		dockpars_energies_next[get_group_id(0)] = best_energy;
+
+		// Zero (0) evals were performed for entity selected with elitism (since it was copied only)
+		dockpars_evals_of_new_entities[get_group_id(0)] = 0;
+	}
+
+	// "best_id" stores the id of the best entity in the population,
+	// Copying genotype and energy value to the first entity of new population
+	barrier(CLK_LOCAL_MEM_FENCE);
+
+	for (gene_counter = get_local_id(0);
+	     gene_counter < dockpars_num_of_genes;
+	     gene_counter+= NUM_OF_THREADS_PER_BLOCK) {
+	     dockpars_conformations_next[GENOTYPE_LENGTH_IN_GLOBMEM*get_group_id(0)+gene_counter] = dockpars_conformations_current[GENOTYPE_LENGTH_IN_GLOBMEM*get_group_id(0) + GENOTYPE_LENGTH_IN_GLOBMEM*best_ID[0]+gene_counter];
+	}
+}
+#endif

--- a/cuda/auxiliary_genetic.cu
+++ b/cuda/auxiliary_genetic.cu
@@ -45,14 +45,14 @@ inline __device__ uint32_t gpu_rand(
 #else
   	// Current state of the threads own PRNG
   	// state = prng_states[get_group_id(0)*NUM_OF_THREADS_PER_BLOCK + get_local_id(0)];
-	state = prng_states[blockIdx.x];
+	state = prng_states[blockIdx.x * blockDim.x + threadIdx.x];
 
 	// Calculating next state
   	state = (RAND_A*state+RAND_C);
 #endif
   	// Saving next state to memory
   	// prng_states[get_group_id(0)*NUM_OF_THREADS_PER_BLOCK + get_local_id(0)] = state;
-	prng_states[blockIdx.x] = state;
+	prng_states[blockIdx.x * blockDim.x + threadIdx.x] = state;
 
   return state;
 }

--- a/cuda/calcMergeEneGra.cu
+++ b/cuda/calcMergeEneGra.cu
@@ -189,9 +189,9 @@ __device__ void gpu_calc_energrad(
 			calc_coords[atom_id].w = qt.w + rotation_movingvec.w;
 
 		} // End if-statement not dummy rotation
-
-        __syncthreads();
         __threadfence();
+        __syncthreads();
+
 
 	} // End rotation_counter for-loop
 

--- a/cuda/calcMergeEneGra.cu
+++ b/cuda/calcMergeEneGra.cu
@@ -795,8 +795,8 @@ __device__ void gpu_calc_energrad(
 		// Finding the index-position of "grad_delta" in the "angle_const" array
 		//uint index_theta    = floor(native_divide(current_theta    - angle_const[0], angle_delta));
 		//uint index_rotangle = floor(native_divide(current_rotangle - angle_const[0], angle_delta));
-		uint index_theta    = floor((current_theta    - cData.mem_angle_const[0]) * inv_angle_delta);
-		uint index_rotangle = floor((current_rotangle - cData.mem_angle_const[0]) * inv_angle_delta);
+		uint index_theta    = floor((current_theta    - cData.pMem_angle_const[0]) * inv_angle_delta);
+		uint index_rotangle = floor((current_rotangle - cData.pMem_angle_const[0]) * inv_angle_delta);
 
 		// Interpolating theta values
 		// X0 -> index - 1
@@ -815,13 +815,13 @@ __device__ void gpu_calc_energrad(
 		// Using interpolation on out-of-bounds elements results in hang
 		if ((index_theta <= 0) || (index_theta >= 999))
 		{
-			dependence_on_theta = cData.mem_dependence_on_theta_const[stick_to_bounds(index_theta,0,999)];
+			dependence_on_theta = cData.pMem_dependence_on_theta_const[stick_to_bounds(index_theta,0,999)];
 		} else
 		{
-			X0 = cData.mem_angle_const[index_theta];
-			X1 = cData.mem_angle_const[index_theta+1];
-			Y0 = cData.mem_dependence_on_theta_const[index_theta];
-			Y1 = cData.mem_dependence_on_theta_const[index_theta+1];
+			X0 = cData.pMem_angle_const[index_theta];
+			X1 = cData.pMem_angle_const[index_theta+1];
+			Y0 = cData.pMem_dependence_on_theta_const[index_theta];
+			Y1 = cData.pMem_dependence_on_theta_const[index_theta+1];
 			dependence_on_theta = (Y0 * (X1-current_theta) + Y1 * (current_theta-X0)) * inv_angle_delta;
 		}
 		
@@ -836,13 +836,13 @@ __device__ void gpu_calc_energrad(
 		// Using interpolation on out-of-bounds elements results in hang
 		if ((index_rotangle <= 0) || (index_rotangle >= 999))
 		{
-			dependence_on_rotangle = cData.mem_dependence_on_rotangle_const[stick_to_bounds(index_rotangle,0,999)];
+			dependence_on_rotangle = cData.pMem_dependence_on_rotangle_const[stick_to_bounds(index_rotangle,0,999)];
 		} else
 		{
-			X0 = cData.mem_angle_const[index_rotangle];
-			X1 = cData.mem_angle_const[index_rotangle+1];
-			Y0 = cData.mem_dependence_on_rotangle_const[index_rotangle];
-			Y1 = cData.mem_dependence_on_rotangle_const[index_rotangle+1];
+			X0 = cData.pMem_angle_const[index_rotangle];
+			X1 = cData.pMem_angle_const[index_rotangle+1];
+			Y0 = cData.pMem_dependence_on_rotangle_const[index_rotangle];
+			Y1 = cData.pMem_dependence_on_rotangle_const[index_rotangle+1];
 			dependence_on_rotangle = (Y0 * (X1-current_rotangle) + Y1 * (current_rotangle-X0)) * inv_angle_delta;
 		}
 
@@ -877,12 +877,12 @@ __device__ void gpu_calc_energrad(
 		uint32_t rotable_atom_cnt = idx / num_torsion_genes;
 		uint32_t rotbond_id = idx - rotable_atom_cnt * num_torsion_genes; // this is a bit cheaper than % (modulo)
 
-		if (rotable_atom_cnt >= cData.mem_num_rotating_atoms_per_rotbond_const[rotbond_id])
+		if (rotable_atom_cnt >= cData.pMem_num_rotating_atoms_per_rotbond_const[rotbond_id])
 			continue; // Nothing to do
 
 		// Querying ids of atoms belonging to the rotatable bond in question
-		int atom1_id = cData.mem_rotbonds_const[2*rotbond_id];
-		int atom2_id = cData.mem_rotbonds_const[2*rotbond_id+1];
+		int atom1_id = cData.pMem_rotbonds_const[2*rotbond_id];
+		int atom2_id = cData.pMem_rotbonds_const[2*rotbond_id+1];
 
 		float3 atomRef_coords;
 		atomRef_coords.x = calc_coords[atom1_id].x;
@@ -899,7 +899,7 @@ __device__ void gpu_calc_energrad(
         rotation_unitvec.z *= l;
 
 		// Torque of torsions
-		uint lig_atom_id = cData.mem_rotbonds_atoms_const[MAX_NUM_OF_ATOMS*rotbond_id + rotable_atom_cnt];
+		uint lig_atom_id = cData.pMem_rotbonds_atoms_const[MAX_NUM_OF_ATOMS*rotbond_id + rotable_atom_cnt];
 		float4 torque_tor;
         float3 r, atom_force;
 

--- a/cuda/calcMergeEneGra.cu
+++ b/cuda/calcMergeEneGra.cu
@@ -203,7 +203,7 @@ __device__ void gpu_calc_energrad(
 	float cube[8];
 	for (uint32_t atom_id = threadIdx.x;
 	              atom_id < cData.dockpars.num_of_atoms;
-	              atom_id+= blockIdx.x)
+	              atom_id+= blockDim.x)
 	{
 		float x = calc_coords[atom_id].x;
 		float y = calc_coords[atom_id].y;

--- a/cuda/calcMergeEneGra.cu
+++ b/cuda/calcMergeEneGra.cu
@@ -1,0 +1,941 @@
+/*
+
+AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian Genetic Algorithm
+Copyright (C) 2017 TU Darmstadt, Embedded Systems and Applications Group, Germany. All rights reserved.
+For some of the code, Copyright (C) 2019 Computational Structural Biology Center, the Scripps Research Institute.
+
+AutoDock is a Trade Mark of the Scripps Research Institute.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+
+
+// IMPORTANT: The following block contains definitions
+// already made either in energy or gradient calculation files.
+// For that reason, these are commented here.
+
+// IMPORTANT: the code of gradient calculation was the initial template.
+// Then, statements corresponding to enery calculations were added gradually.
+// The latter can be distinguised this way: they are place within lines without indentation.
+
+__device__ void gpu_calc_energrad(
+			float* genotype,
+			float& global_energy,
+			int&   run_id,
+
+            float4* calc_coords,
+#if defined (DEBUG_ENERGY_KERNEL)
+			float& interE,
+			float& pintraE,
+#endif
+
+		    // Gradient-related arguments
+		    // Calculate gradients (forces) for intermolecular energy
+		    // Derived from autodockdev/maps.py
+		    // "is_enabled_gradient_calc": enables gradient calculation.
+		    // In Genetic-Generation: no need for gradients
+		    // In Gradient-Minimizer: must calculate gradients
+			float* gradient_inter_x,
+			float* gradient_inter_y,
+			float* gradient_inter_z,
+			float* gradient_intra_x,
+			float* gradient_intra_y,
+			float* gradient_intra_z,
+			float* gradient_genotype,
+            unsigned long long int* pAccumulator64
+)
+{
+	float energy = 0.0f;
+#if defined (DEBUG_ENERGY_KERNEL)
+	interE = 0.0f;
+	intraE = 0.0f;
+#endif
+
+	// Initializing gradients (forces) 
+	// Derived from autodockdev/maps.py
+	for (uint32_t atom_id = threadIdx.x;
+		  atom_id < MAX_NUM_OF_ATOMS; // makes sure that gradient sum reductions give correct results if dockpars_num_atoms < NUM_OF_THREADS_PER_BLOCK
+		  atom_id+= blockDim.x) {
+		// Initialize coordinates
+		calc_coords[atom_id].x = cData.pKerconst_conform->ref_coords_const[3*atom_id];
+        calc_coords[atom_id].y = cData.pKerconst_conform->ref_coords_const[3*atom_id+1];
+        calc_coords[atom_id].z = cData.pKerconst_conform->ref_coords_const[3*atom_id+2];
+        calc_coords[atom_id].w = 0.0f;
+
+		// Intermolecular gradients
+		gradient_inter_x[atom_id] = (float)0;
+		gradient_inter_y[atom_id] = (float)0;
+		gradient_inter_z[atom_id] = (float)0;
+		// Intramolecular gradients
+		gradient_intra_x[atom_id] = (float)0;
+		gradient_intra_y[atom_id] = (float)0;
+		gradient_intra_z[atom_id] = (float)0;
+	}
+
+	// Initializing gradient genotypes
+	for (int gene_cnt = threadIdx.x;
+		  gene_cnt < cData.dockpars.num_of_genes;
+		  gene_cnt+= blockDim.x) {
+		gradient_genotype[gene_cnt] = 0.0f;
+	}
+
+	// General rotation moving vector
+	float4 genrot_movingvec;
+	genrot_movingvec.x = genotype[0];
+	genrot_movingvec.y = genotype[1];
+	genrot_movingvec.z = genotype[2];
+	genrot_movingvec.w = 0.0;
+
+	// Convert orientation genes from sex. to radians
+	float phi         = genotype[3] * DEG_TO_RAD;
+	float theta       = genotype[4] * DEG_TO_RAD;
+	float genrotangle = genotype[5] * DEG_TO_RAD;
+
+	float4 genrot_unitvec;
+	float sin_angle = sin(theta);
+	float s2 = sin(genrotangle*0.5f);
+	genrot_unitvec.x = s2*sin_angle*cos(phi);
+	genrot_unitvec.y = s2*sin_angle*sin(phi);
+	genrot_unitvec.z = s2*cos(theta);
+	genrot_unitvec.w = cos(genrotangle*0.5f);
+	bool is_theta_gt_pi = 1.0-2.0*(float)(sin_angle < 0.0f);
+
+	uint32_t  g1 = cData.dockpars.gridsize_x;
+	uint32_t  g2 = cData.dockpars.gridsize_x_times_y;
+	uint32_t  g3 = cData.dockpars.gridsize_x_times_y_times_z;
+
+    __threadfence();
+    __syncthreads();
+
+	// ================================================
+	// CALCULATING ATOMIC POSITIONS AFTER ROTATIONS
+	// ================================================
+	for (uint32_t rotation_counter = threadIdx.x;
+	              rotation_counter < cData.dockpars.rotbondlist_length;
+	              rotation_counter+=blockDim.x)
+	{
+		int rotation_list_element = cData.pKerconst_rotlist->rotlist_const[rotation_counter];
+
+		if ((rotation_list_element & RLIST_DUMMY_MASK) == 0)	// If not dummy rotation
+		{
+			uint32_t atom_id = rotation_list_element & RLIST_ATOMID_MASK;
+
+			// Capturing atom coordinates
+			float4 atom_to_rotate = calc_coords[atom_id];
+
+			// initialize with general rotation values
+			float4 rotation_unitvec = genrot_unitvec;
+			float4 rotation_movingvec = genrot_movingvec;
+
+			if ((rotation_list_element & RLIST_GENROT_MASK) == 0) // If rotating around rotatable bond
+			{
+				uint32_t rotbond_id = (rotation_list_element & RLIST_RBONDID_MASK) >> RLIST_RBONDID_SHIFT;
+
+				float rotation_angle = genotype[6+rotbond_id]*DEG_TO_RAD*0.5f;
+				float s = sin(rotation_angle);
+                rotation_unitvec.x = s*cData.pKerconst_conform->rotbonds_unit_vectors_const[3*rotbond_id];
+                rotation_unitvec.y = s*cData.pKerconst_conform->rotbonds_unit_vectors_const[3*rotbond_id+1];
+                rotation_unitvec.z = s*cData.pKerconst_conform->rotbonds_unit_vectors_const[3*rotbond_id+2];
+                rotation_unitvec.w = cos(rotation_angle);
+                rotation_movingvec.x = cData.pKerconst_conform->rotbonds_moving_vectors_const[3*rotbond_id];
+                rotation_movingvec.y = cData.pKerconst_conform->rotbonds_moving_vectors_const[3*rotbond_id+1];
+                rotation_movingvec.z = cData.pKerconst_conform->rotbonds_moving_vectors_const[3*rotbond_id+2];
+                rotation_movingvec.w = 0.0f;
+                
+				// Performing additionally the first movement which
+				// is needed only if rotating around rotatable bond
+				atom_to_rotate.x -= rotation_movingvec.x;
+				atom_to_rotate.y -= rotation_movingvec.y;
+				atom_to_rotate.z -= rotation_movingvec.z;
+				atom_to_rotate.w -= rotation_movingvec.w;
+			}
+
+			float4 quatrot_left = rotation_unitvec;
+			// Performing rotation
+			if ((rotation_list_element & RLIST_GENROT_MASK) != 0)	// If general rotation,
+										// two rotations should be performed
+										// (multiplying the quaternions)
+			{
+				// Calculating quatrot_left*ref_orientation_quats_const,
+				// which means that reference orientation rotation is the first
+				uint32_t rid4 = 4 * run_id;
+				float4 qt;
+                qt.x = cData.pKerconst_conform->ref_orientation_quats_const[rid4+0];
+                qt.y = cData.pKerconst_conform->ref_orientation_quats_const[rid4+1];
+                qt.z = cData.pKerconst_conform->ref_orientation_quats_const[rid4+2];
+                qt.w = cData.pKerconst_conform->ref_orientation_quats_const[rid4+3];
+				quatrot_left = quaternion_multiply(quatrot_left, qt);
+			}
+
+			// Performing final movement and storing values
+            float4 qt = quaternion_rotate(atom_to_rotate,quatrot_left);
+			calc_coords[atom_id].x = qt.x + rotation_movingvec.x;
+			calc_coords[atom_id].y = qt.y + rotation_movingvec.y;
+			calc_coords[atom_id].z = qt.z + rotation_movingvec.z;            
+			calc_coords[atom_id].w = qt.w + rotation_movingvec.w;
+
+		} // End if-statement not dummy rotation
+
+        __syncthreads();
+        __threadfence();
+
+	} // End rotation_counter for-loop
+
+	// ================================================
+	// CALCULATING INTERMOLECULAR GRADIENTS
+	// ================================================
+	float weights[8];
+	float cube[8];
+	for (uint32_t atom_id = threadIdx.x;
+	              atom_id < cData.dockpars.num_of_atoms;
+	              atom_id+= blockIdx.x)
+	{
+		float x = calc_coords[atom_id].x;
+		float y = calc_coords[atom_id].y;
+		float z = calc_coords[atom_id].z;
+		float q = cData.pKerconst_interintra->atom_charges_const[atom_id];
+		uint32_t atom_typeid = cData.pKerconst_interintra->atom_types_const[atom_id];
+
+		if ((x < 0) || (y < 0) || (z < 0) || (x >= cData.dockpars.gridsize_x-1)
+				                  || (y >= cData.dockpars.gridsize_y-1)
+						  || (z >= cData.dockpars.gridsize_z-1)){
+			x -= 0.5f * cData.dockpars.gridsize_x;
+			y -= 0.5f * cData.dockpars.gridsize_y;
+			z -= 0.5f * cData.dockpars.gridsize_z;
+			energy += 21.0f * (x*x+y*y+z*z); //100000.0f;
+			#if defined (DEBUG_ENERGY_KERNEL)
+			interE += 21.0f * (x*x+y*y+z*z);
+			#endif
+			// Setting gradients (forces) penalties.
+			// The idea here is to push the offending
+			// molecule towards the center rather
+			gradient_inter_x[atom_id] += 42.0f * x;
+			gradient_inter_y[atom_id] += 42.0f * y;
+			gradient_inter_z[atom_id] += 42.0f * z;
+			continue;
+		}
+		// Getting coordinates
+		float x_low  = floor(x);
+		float y_low  = floor(y);
+		float z_low  = floor(z);
+
+		// Grid value at 000
+		float* grid_value_000 = cData.pMem_fgrids + ((ulong)(x_low  + y_low*g1  + z_low*g2)<<2);
+
+		float dx = x - x_low;
+		float omdx = 1.0f - dx;
+		float dy = y - y_low; 
+		float omdy = 1.0f - dy;
+		float dz = z - z_low;
+		float omdz = 1.0f - dz;
+
+		// Calculating interpolation weights
+		weights [idx_000] = omdx*omdy*omdz;
+		weights [idx_010] = omdx*dy*omdz;
+		weights [idx_001] = omdx*omdy*dz;
+		weights [idx_011] = omdx*dy*dz;
+		weights [idx_100] = dx*omdy*omdz;
+		weights [idx_110] = dx*dy*omdz;
+		weights [idx_101] = dx*omdy*dz;
+		weights [idx_111] = dx*dy*dz;
+
+		ulong mul_tmp = atom_typeid*g3<<2;
+		cube[0] = *(grid_value_000+mul_tmp+0);
+		cube[1] = *(grid_value_000+mul_tmp+1);
+		cube[2] = *(grid_value_000+mul_tmp+2);
+		cube[3] = *(grid_value_000+mul_tmp+3);
+		cube[4] = *(grid_value_000+mul_tmp+4);
+		cube[5] = *(grid_value_000+mul_tmp+5);
+		cube[6] = *(grid_value_000+mul_tmp+6);
+		cube[7] = *(grid_value_000+mul_tmp+7);
+		// Calculating affinity energy
+		energy += cube[0]*weights[0] + cube[1]*weights[1] + cube[2]*weights[2] + cube[3]*weights[3] + cube[4]*weights[4] + cube[5]*weights[5] + cube[6]*weights[6] + cube[7]*weights[7];
+		#if defined (DEBUG_ENERGY_KERNEL)
+		interE += cube[0]*weights[0] + cube[1]*weights[1] + cube[2]*weights[2] + cube[3]*weights[3] + cube[4]*weights[4] + cube[5]*weights[5] + cube[6]*weights[6] + cube[7]*weights[7];
+		#endif
+		// -------------------------------------------------------------------
+		// Deltas dx, dy, dz are already normalized 
+		// (by host/src/getparameters.cpp) in AutoDock-GPU.
+		// The correspondance between vertices in xyz axes is:
+		// 0, 1, 2, 3, 4, 5, 6, 7  and  000, 100, 010, 001, 101, 110, 011, 111
+		// -------------------------------------------------------------------
+		/*
+		    deltas: (x-x0)/(x1-x0), (y-y0...
+		    vertices: (000, 100, 010, 001, 101, 110, 011, 111)        
+
+			  Z
+			  '
+			  3 - - - - 6
+			 /.        /|
+			4 - - - - 7 |
+			| '       | |
+			| 0 - - - + 2 -- Y
+			'/        |/
+			1 - - - - 5
+		       /
+		      X
+		*/
+
+		// -------------------------------------------------------------------
+		// Calculating gradients (forces) corresponding to 
+		// "atype" intermolecular energy
+		// Derived from autodockdev/maps.py
+		// -------------------------------------------------------------------
+
+		// Vector in x-direction
+/*		x10 = cube [idx_100] - cube [idx_000]; // z = 0
+		x52 = cube [idx_110] - cube [idx_010]; // z = 0
+		x43 = cube [idx_101] - cube [idx_001]; // z = 1
+		x76 = cube [idx_111] - cube [idx_011]; // z = 1
+		vx_z0 = omdy * x10 + dy * x52;     // z = 0
+		vx_z1 = omdy * x43 + dy * x76;     // z = 1
+		gradient_inter_x[atom_id] += omdz * vx_z0 + dz * vx_z1;
+
+		// AT - reduced to two variables:
+		vx_z0 = omdy * (cube [idx_100] - cube [idx_000]) + dy * (cube [idx_110] - cube [idx_010]);     // z = 0
+		vx_z1 = omdy * (cube [idx_101] - cube [idx_001]) + dy * (cube [idx_111] - cube [idx_011]);     // z = 1 */
+
+		// AT - all in one go with no intermediate variables (following calcs are similar)
+		// Vector in x-direction
+		gradient_inter_x[atom_id] += omdz * (omdy * (cube [idx_100] - cube [idx_000]) + dy * (cube [idx_110] - cube [idx_010])) +
+		                               dz * (omdy * (cube [idx_101] - cube [idx_001]) + dy * (cube [idx_111] - cube [idx_011]));
+		// Vector in y-direction
+		gradient_inter_y[atom_id] += omdz * (omdx * (cube [idx_010] - cube [idx_000]) + dx * (cube [idx_110] - cube [idx_100])) +
+		                               dz * (omdx * (cube [idx_011] - cube [idx_001]) + dx * (cube [idx_111] - cube [idx_101]));
+		// Vectors in z-direction
+		gradient_inter_z[atom_id] += omdy * (omdx * (cube [idx_001] - cube [idx_000]) + dx * (cube [idx_101] - cube [idx_100])) +
+		                               dy * (omdx * (cube [idx_011] - cube [idx_010]) + dx * (cube [idx_111] - cube [idx_110]));
+		// -------------------------------------------------------------------
+		// Calculating gradients (forces) corresponding to 
+		// "elec" intermolecular energy
+		// Derived from autodockdev/maps.py
+		// -------------------------------------------------------------------
+
+		// Capturing electrostatic values
+		atom_typeid = cData.dockpars.num_of_atypes;
+
+		mul_tmp = atom_typeid*g3<<2; // different atom type id to get charge IA
+		cube[0] = *(grid_value_000+mul_tmp+0);
+		cube[1] = *(grid_value_000+mul_tmp+1);
+		cube[2] = *(grid_value_000+mul_tmp+2);
+		cube[3] = *(grid_value_000+mul_tmp+3);
+		cube[4] = *(grid_value_000+mul_tmp+4);
+		cube[5] = *(grid_value_000+mul_tmp+5);
+		cube[6] = *(grid_value_000+mul_tmp+6);
+		cube[7] = *(grid_value_000+mul_tmp+7);
+
+		// Calculating affinity energy
+		energy += q * (cube[0]*weights[0] + cube[1]*weights[1] + cube[2]*weights[2] + cube[3]*weights[3] + cube[4]*weights[4] + cube[5]*weights[5] + cube[6]*weights[6] + cube[7]*weights[7]);
+		#if defined (DEBUG_ENERGY_KERNEL)
+		interE += q *(cube[0]*weights[0] + cube[1]*weights[1] + cube[2]*weights[2] + cube[3]*weights[3] + cube[4]*weights[4] + cube[5]*weights[5] + cube[6]*weights[6] + cube[7]*weights[7]);
+		#endif
+
+		// Vector in x-direction
+		gradient_inter_x[atom_id] += q * ( omdz * (omdy * (cube [idx_100] - cube [idx_000]) + dy * (cube [idx_110] - cube [idx_010])) +
+		                                     dz * (omdy * (cube [idx_101] - cube [idx_001]) + dy * (cube [idx_111] - cube [idx_011])));
+		// Vector in y-direction
+		gradient_inter_y[atom_id] += q * ( omdz * (omdx * (cube [idx_010] - cube [idx_000]) + dx * (cube [idx_110] - cube [idx_100])) +
+		                                     dz * (omdx * (cube [idx_011] - cube [idx_001]) + dx * (cube [idx_111] - cube [idx_101])));
+		// Vectors in z-direction
+		gradient_inter_z[atom_id] += q * ( omdy * (omdx * (cube [idx_001] - cube [idx_000]) + dx * (cube [idx_101] - cube [idx_100])) +
+		                                     dy * (omdx * (cube [idx_011] - cube [idx_010]) + dx * (cube [idx_111] - cube [idx_110])));
+		// -------------------------------------------------------------------
+		// Calculating gradients (forces) corresponding to 
+		// "dsol" intermolecular energy
+		// Derived from autodockdev/maps.py
+		// -------------------------------------------------------------------
+		// Need only magnitude of charge from here on down
+		q = fabs(q);
+		// Capturing desolvation values (atom_typeid+1 compared to above => mul_tmp + g3*4)
+		mul_tmp += g3<<2;
+		cube[0] = *(grid_value_000+mul_tmp+0);
+		cube[1] = *(grid_value_000+mul_tmp+1);
+		cube[2] = *(grid_value_000+mul_tmp+2);
+		cube[3] = *(grid_value_000+mul_tmp+3);
+		cube[4] = *(grid_value_000+mul_tmp+4);
+		cube[5] = *(grid_value_000+mul_tmp+5);
+		cube[6] = *(grid_value_000+mul_tmp+6);
+		cube[7] = *(grid_value_000+mul_tmp+7);
+
+		// Calculating affinity energy
+		energy += q * (cube[0]*weights[0] + cube[1]*weights[1] + cube[2]*weights[2] + cube[3]*weights[3] + cube[4]*weights[4] + cube[5]*weights[5] + cube[6]*weights[6] + cube[7]*weights[7]);
+		#if defined (DEBUG_ENERGY_KERNEL)
+		interE += q *(cube[0]*weights[0] + cube[1]*weights[1] + cube[2]*weights[2] + cube[3]*weights[3] + cube[4]*weights[4] + cube[5]*weights[5] + cube[6]*weights[6] + cube[7]*weights[7]);
+		#endif
+
+		// Vector in x-direction
+		gradient_inter_x[atom_id] += q * ( omdz * (omdy * (cube [idx_100] - cube [idx_000]) + dy * (cube [idx_110] - cube [idx_010])) +
+		                                     dz * (omdy * (cube [idx_101] - cube [idx_001]) + dy * (cube [idx_111] - cube [idx_011])));
+		// Vector in y-direction
+		gradient_inter_y[atom_id] += q * ( omdz * (omdx * (cube [idx_010] - cube [idx_000]) + dx * (cube [idx_110] - cube [idx_100])) +
+		                                     dz * (omdx * (cube [idx_011] - cube [idx_001]) + dx * (cube [idx_111] - cube [idx_101])));
+		// Vectors in z-direction
+		gradient_inter_z[atom_id] += q * ( omdy * (omdx * (cube [idx_001] - cube [idx_000]) + dx * (cube [idx_101] - cube [idx_100])) +
+		                                     dy * (omdx * (cube [idx_011] - cube [idx_010]) + dx * (cube [idx_111] - cube [idx_110])));
+		// -------------------------------------------------------------------
+	} // End atom_id for-loop (INTERMOLECULAR ENERGY)
+
+	// Inter- and intra-molecular energy calculation
+	// are independent from each other, so NO barrier is needed here.
+	// As these two require different operations,
+	// they can be executed only sequentially on the GPU.
+	float delta_distance = 0.5f * cData.dockpars.smooth;
+	float smoothed_distance;
+
+	// ================================================
+	// CALCULATING INTRAMOLECULAR GRADIENTS
+	// ================================================
+	for (uint32_t contributor_counter = threadIdx.x;
+	              contributor_counter < cData.dockpars.num_of_intraE_contributors;
+	              contributor_counter+= blockDim.x)
+	{
+		// Storing in a private variable 
+		// the gradient contribution of each contributing atomic pair
+		float priv_gradient_per_intracontributor= 0.0f;
+
+		// Getting atom IDs
+		uint32_t atom1_id = cData.pKerconst_intracontrib->intraE_contributors_const[3*contributor_counter];
+		uint32_t atom2_id = cData.pKerconst_intracontrib->intraE_contributors_const[3*contributor_counter+1];
+		uint32_t hbond = (uint32_t)(cData.pKerconst_intracontrib->intraE_contributors_const[3*contributor_counter+2] == 1);	// evaluates to 1 in case of H-bond, 0 otherwise
+
+		// Calculating vector components of vector going
+		// from first atom's to second atom's coordinates
+		float subx = calc_coords[atom1_id].x - calc_coords[atom2_id].x;
+		float suby = calc_coords[atom1_id].y - calc_coords[atom2_id].y;
+		float subz = calc_coords[atom1_id].z - calc_coords[atom2_id].z;
+
+		// Calculating atomic_distance
+		float dist = sqrt(subx*subx + suby*suby + subz*subz);
+		float atomic_distance = dist * cData.dockpars.grid_spacing;
+
+		// Getting type IDs
+		uint32_t atom1_typeid = cData.pKerconst_interintra->atom_types_const[atom1_id];
+		uint32_t atom2_typeid = cData.pKerconst_interintra->atom_types_const[atom2_id];
+
+		uint32_t atom1_type_vdw_hb = cData.pKerconst_intra->atom1_types_reqm_const [atom1_typeid];
+		uint32_t atom2_type_vdw_hb = cData.pKerconst_intra->atom2_types_reqm_const [atom2_typeid];
+
+		// ------------------------------------------------
+		// Required only for flexrings
+		// Checking if this is a CG-G0 atomic pair.
+		// If so, then adding energy term (E = G * distance).
+		// Initial specification required NON-SMOOTHED distance.
+		// This interaction is evaluated at any distance,
+		// so no cuttoffs considered here!
+		// vbond is G when calculating flexrings, 0.0 otherwise
+		float vbond = G * (float)(((atom1_type_vdw_hb == ATYPE_CG_IDX) && (atom2_type_vdw_hb == ATYPE_G0_IDX)) ||
+					  ((atom1_type_vdw_hb == ATYPE_G0_IDX) && (atom2_type_vdw_hb == ATYPE_CG_IDX)));
+		energy += vbond * atomic_distance;
+		priv_gradient_per_intracontributor += vbond;
+		// ------------------------------------------------
+
+		// Calculating energy contributions
+		// Cuttoff1: internuclear-distance at 8A only for vdw and hbond.
+		if (atomic_distance < 8.0f)
+		{
+			// Getting optimum pair distance (opt_distance) from reqm and reqm_hbond
+			// reqm: equilibrium internuclear separation 
+			//       (sum of the vdW radii of two like atoms (A)) in the case of vdW
+			// reqm_hbond: equilibrium internuclear separation
+			//  	 (sum of the vdW radii of two like atoms (A)) in the case of hbond 
+			float opt_distance = (cData.pKerconst_intra->reqm_const [atom1_type_vdw_hb+ATYPE_NUM*hbond] + cData.pKerconst_intra->reqm_const [atom2_type_vdw_hb+ATYPE_NUM*hbond]);
+
+			// Getting smoothed distance
+			// smoothed_distance = function(atomic_distance, opt_distance)
+			float opt_dist_delta = opt_distance - atomic_distance;
+			if(fabs(opt_dist_delta)>=delta_distance){
+				smoothed_distance = atomic_distance + copysign(delta_distance,opt_dist_delta);
+			} else smoothed_distance = opt_distance;
+			// Calculating van der Waals / hydrogen bond term
+			uint32_t idx = atom1_typeid * cData.dockpars.num_of_atypes + atom2_typeid;
+			float nvbond = 1.0 - vbond;
+			float A = nvbond * cData.pKerconst_intra->VWpars_AC_const[idx] / pow(smoothed_distance,12);
+			float B = nvbond * cData.pKerconst_intra->VWpars_BD_const[idx] / pow(smoothed_distance,6+4*hbond);
+			energy += A - B;
+			priv_gradient_per_intracontributor += ((6.0f+4.0f*hbond) * B - 12.0f * A) / smoothed_distance;
+			#if defined (DEBUG_ENERGY_KERNEL)
+			intraE += A - B;
+			#endif
+		} // if cuttoff1 - internuclear-distance at 8A
+
+		// Calculating energy contributions
+		// Cuttoff2: internuclear-distance at 20.48A only for el and sol.
+		if (atomic_distance < 20.48f)
+		{
+			float q1 = cData.pKerconst_interintra->atom_charges_const[atom1_id];
+			float q2 = cData.pKerconst_interintra->atom_charges_const[atom2_id];
+//			float exp_el = native_exp(DIEL_B_TIMES_H*atomic_distance);
+			float dist2 = atomic_distance*atomic_distance;
+			// Calculating desolvation term
+			// 1/25.92 = 0.038580246913580245
+			float desolv_energy =  ((cData.pKerconst_intra->dspars_S_const[atom1_typeid] +
+						 cData.dockpars.qasp*fabs(q1)) * cData.pKerconst_intra->dspars_V_const[atom2_typeid] +
+						(cData.pKerconst_intra->dspars_S_const[atom2_typeid] +
+						 cData.dockpars.qasp*fabs(q2)) * cData.pKerconst_intra->dspars_V_const[atom1_typeid]) *
+                               (
+								cData.dockpars.coeff_desolv*(12.96f-0.1063f*dist2*(1.0f-0.001947f*dist2)) /
+								(12.96f+dist2*(0.4137f+dist2*(0.00357f+0.000112f*dist2)))
+							      );
+
+            // Calculating electrostatic term
+			float dist_shift=atomic_distance+1.588f;
+			dist2=dist_shift*dist_shift;
+			float disth_shift=atomic_distance+0.794f;
+			float disth4=disth_shift*disth_shift;
+			disth4*=disth4;
+			float diel = 1.404f / dist2 + 0.072f / disth4 + 0.00831f;
+			float es_energy = cData.dockpars.coeff_elec * q1 * q2 / atomic_distance;
+			energy += diel * es_energy + desolv_energy;
+
+			#if defined (DEBUG_ENERGY_KERNEL)
+            intraE += diel * es_energy + desolv_energy;
+			#endif
+
+			// http://www.wolframalpha.com/input/?i=1%2F(x*(A%2B(B%2F(1%2BK*exp(-h*B*x)))))
+/*			float exp_el_DIEL_K = exp_el + DIEL_K;
+			float upper = DIEL_A * exp_el_DIEL_K*exp_el_DIEL_K +
+				      DIEL_B * exp_el * (DIEL_B_TIMES_H_TIMES_K*atomic_distance + exp_el_DIEL_K);
+			float lower = atomic_distance * (DIEL_A * exp_el_DIEL_K + DIEL_B * exp_el);
+			lower *= lower;*/
+
+//			priv_gradient_per_intracontributor +=  -dockpars_coeff_elec * q1 * q2 * native_divide (upper, lower) -
+//								0.0771605f * atomic_distance * desolv_energy;
+			priv_gradient_per_intracontributor +=  -(es_energy / atomic_distance) * diel - es_energy * ((2.808f / (dist2*dist_shift)) + (0.288f / (disth4*disth_shift))) -
+								0.0771605f * atomic_distance * desolv_energy; // 1/3.6^2 = 1/12.96 = 0.0771605
+		} // if cuttoff2 - internuclear-distance at 20.48A
+
+
+		// Decomposing "priv_gradient_per_intracontributor"
+		// into the contribution of each atom of the pair.
+		// Distances in Angstroms of vector that goes from
+		// "atom1_id"-to-"atom2_id", therefore - subx, - suby, and - subz are used
+		float grad_div_dist = -priv_gradient_per_intracontributor / dist;
+		float priv_intra_gradient_x = subx * grad_div_dist;
+		float priv_intra_gradient_y = suby * grad_div_dist;
+		float priv_intra_gradient_z = subz * grad_div_dist;
+		
+		// Calculating gradients in xyz components.
+		// Gradients for both atoms in a single contributor pair
+		// have the same magnitude, but opposite directions
+		ATOMICSUBF32(&gradient_intra_x[atom1_id], priv_intra_gradient_x);
+		ATOMICSUBF32(&gradient_intra_y[atom1_id], priv_intra_gradient_y);
+		ATOMICSUBF32(&gradient_intra_z[atom1_id], priv_intra_gradient_z);
+
+		ATOMICADDF32(&gradient_intra_x[atom2_id], priv_intra_gradient_x);
+		ATOMICADDF32(&gradient_intra_y[atom2_id], priv_intra_gradient_y);
+		ATOMICADDF32(&gradient_intra_z[atom2_id], priv_intra_gradient_z);
+	} // End contributor_counter for-loop (INTRAMOLECULAR ENERGY)
+	__threadfence();
+    __syncthreads();
+    
+
+
+	// Accumulating inter- and intramolecular gradients
+	for (uint32_t atom_cnt = threadIdx.x;
+		  atom_cnt < cData.dockpars.num_of_atoms;
+		  atom_cnt+= blockDim.x) {
+
+		// Grid gradients were calculated in the grid space,
+		// so they have to be put back in Angstrom.
+
+		// Intramolecular gradients were already in Angstrom,
+		// so no scaling for them is required.
+		float grad_total_x = (gradient_inter_x[atom_cnt] / cData.dockpars.grid_spacing);
+		float grad_total_y = (gradient_inter_y[atom_cnt] / cData.dockpars.grid_spacing);
+		float grad_total_z = (gradient_inter_z[atom_cnt] / cData.dockpars.grid_spacing);
+
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		if (atom_cnt == 0) {
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%s\n", "Gradients: inter and intra");
+			printf("%10s %13s %13s %13s %5s %13s %13s %13s\n", "atom_id", "grad_intER.x", "grad_intER.y", "grad_intER.z", "|", "grad_intRA.x", "grad_intRA.y", "grad_intRA.z");
+		}
+		printf("%10u %13.6f %13.6f %13.6f %5s %13.6f %13.6f %13.6f\n", atom_cnt, grad_total_x, grad_total_y, grad_total_z, "|", gradient_intra_x[atom_cnt], gradient_intra_y[atom_cnt], gradient_intra_z[atom_cnt]);
+		#endif
+
+		grad_total_x += gradient_intra_x[atom_cnt];
+		grad_total_y += gradient_intra_y[atom_cnt];
+		grad_total_z += gradient_intra_z[atom_cnt];
+		// Re-using "gradient_inter_*" for total gradient (inter+intra)
+		gradient_inter_x[atom_cnt] = grad_total_x;
+		gradient_inter_y[atom_cnt] = grad_total_y;
+		gradient_inter_z[atom_cnt] = grad_total_z;
+		
+		// Re-use "gradient_intra_*" for total gradient to do reduction below
+		// - need to prepare by doing thread-wise reduction
+		gradient_intra_x[threadIdx.x] += (float)(atom_cnt==threadIdx.x)*(-gradient_intra_x[threadIdx.x])+grad_total_x; // We need to start sum from 0 but I don't want an if statement
+		gradient_intra_y[threadIdx.x] += (float)(atom_cnt==threadIdx.x)*(-gradient_intra_y[threadIdx.x])+grad_total_y;
+		gradient_intra_z[threadIdx.x] += (float)(atom_cnt==threadIdx.x)*(-gradient_intra_z[threadIdx.x])+grad_total_z;
+
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		if (atom_cnt == 0) {
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%s\n", "Gradients: total = inter + intra");
+			printf("%10s %13s %13s %13s\n", "atom_id", "grad.x", "grad.y", "grad.z");
+		}
+		printf("%10u %13.6f %13.6f %13.6f \n", atom_cnt, gradient_inter_x[atom_cnt], gradient_inter_y[atom_cnt], gradient_inter_z[atom_cnt]);
+		#endif
+	}
+    __threadfence();
+    __syncthreads();
+
+    // TODO
+	// -------------------------------------------------------
+	// Obtaining energy and translation-related gradients
+	// -------------------------------------------------------
+	// reduction over partial energies and prepared "gradient_intra_*" values
+    REDUCEFLOATSUM(energy, pAccumulator64);
+#if defined (DEBUG_ENERGY_KERNEL)
+    REDUCEFLOATSUM(intraE, pAccumulator64);
+#endif    
+    float gx = gradient_intra_x[threadIdx.x];
+    float gy = gradient_intra_y[threadIdx.x];
+    float gz = gradient_intra_z[threadIdx.x];
+    REDUCEFLOATSUM(gx, pAccumulator64);
+    REDUCEFLOATSUM(gy, pAccumulator64);    
+    REDUCEFLOATSUM(gz, pAccumulator64);    
+    
+    global_energy = energy;
+	if (threadIdx.x == 0) {
+
+		// Scaling gradient for translational genes as
+		// their corresponding gradients were calculated in the space
+		// where these genes are in Angstrom,
+		// but AutoDock-GPU translational genes are within in grids
+		gradient_genotype[0] = gx * cData.dockpars.grid_spacing;
+		gradient_genotype[1] = gy * cData.dockpars.grid_spacing;
+		gradient_genotype[2] = gy * cData.dockpars.grid_spacing;
+
+		#if defined (PRINT_GRAD_TRANSLATION_GENES)
+		printf("\n%s\n", "----------------------------------------------------------");
+		printf("gradient_x:%f\n", gradient_genotype [0]);
+		printf("gradient_y:%f\n", gradient_genotype [1]);
+		printf("gradient_z:%f\n", gradient_genotype [2]);
+		#endif
+	}
+    __threadfence();
+    __syncthreads();
+
+	// ------------------------------------------
+	// Obtaining rotation-related gradients
+	// ------------------------------------------ 
+				
+	// Transform gradients_inter_{x|y|z} 
+	// into local_gradients[i] (with four quaternion genes)
+	// Derived from autodockdev/motions.py/forces_to_delta_genes()
+
+	// Transform local_gradients[i] (with four quaternion genes)
+	// into local_gradients[i] (with three Shoemake genes)
+	// Derived from autodockdev/motions.py/_get_cube3_gradient()
+	// ------------------------------------------
+
+	// start by populating "gradient_intra_*" with torque values
+	gradient_intra_x[threadIdx.x] = 0.0;
+	gradient_intra_y[threadIdx.x] = 0.0;
+	gradient_intra_z[threadIdx.x] = 0.0;
+	for (uint32_t atom_cnt = threadIdx.x;
+		  atom_cnt < cData.dockpars.num_of_atoms;
+		  atom_cnt+= blockDim.x) {
+		float4 r;
+        r.x = (calc_coords[atom_cnt].x - genrot_movingvec.x) * cData.dockpars.grid_spacing;
+        r.y = (calc_coords[atom_cnt].y - genrot_movingvec.y) * cData.dockpars.grid_spacing;
+        r.z = (calc_coords[atom_cnt].z - genrot_movingvec.z) * cData.dockpars.grid_spacing;
+        r.w = (calc_coords[atom_cnt].w - genrot_movingvec.w) * cData.dockpars.grid_spacing;
+
+		// Re-using "gradient_inter_*" for total gradient (inter+intra)
+		float4 force;
+		force.x = gradient_inter_x[atom_cnt];
+		force.y = gradient_inter_y[atom_cnt]; 
+		force.z = gradient_inter_z[atom_cnt];
+		force.w = 0.0;
+		float4 torque_rot = cross(r, force);
+		gradient_intra_x[threadIdx.x] += torque_rot.x;
+		gradient_intra_y[threadIdx.x] += torque_rot.y;
+		gradient_intra_z[threadIdx.x] += torque_rot.z;
+	}
+    
+
+	// Do a reduction over the total gradient containing prepared "gradient_intra_*" values    
+    float4 torque_rot;
+    torque_rot.x = gradient_intra_x[threadIdx.x];
+    torque_rot.y = gradient_intra_y[threadIdx.x];
+    torque_rot.z = gradient_intra_z[threadIdx.x];
+    REDUCEFLOATSUM(torque_rot.x, pAccumulator64);
+    REDUCEFLOATSUM(torque_rot.y, pAccumulator64);
+    REDUCEFLOATSUM(torque_rot.z, pAccumulator64);    
+	if (threadIdx.x == 0) {
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		printf("\n%s\n", "----------------------------------------------------------");
+		printf("%-20s %-10.6f %-10.6f %-10.6f\n", "final torque: ", torque_rot.x, torque_rot.y, torque_rot.z);
+		#endif
+
+		// Derived from rotation.py/axisangle_to_q()
+		// genes[3:7] = rotation.axisangle_to_q(torque, rad)
+		float torque_length = norm4df(torque_rot.x, torque_rot.y, torque_rot.z, torque_rot.w);
+		
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		printf("\n%s\n", "----------------------------------------------------------");
+		printf("%-20s %-10.6f\n", "torque length: ", torque_length);
+		#endif
+
+		/*
+		// Infinitesimal rotation in radians
+		const float infinitesimal_radian = 1E-5;
+		*/
+
+		// Finding the quaternion that performs
+		// the infinitesimal rotation around torque axis
+		float4 quat_torque;
+        quat_torque.x = torque_rot.x * SIN_HALF_INFINITESIMAL_RADIAN / torque_length;
+        quat_torque.y = torque_rot.y * SIN_HALF_INFINITESIMAL_RADIAN / torque_length;
+        quat_torque.z = torque_rot.z * SIN_HALF_INFINITESIMAL_RADIAN / torque_length;
+		quat_torque.w = COS_HALF_INFINITESIMAL_RADIAN;
+
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		printf("\n%s\n", "----------------------------------------------------------");
+		printf("%-20s %-10.6f\n", "INFINITESIMAL_RADIAN: ", INFINITESIMAL_RADIAN);
+		printf("%-20s %-10.6f %-10.6f %-10.6f %-10.6f\n", "quat_torque (w,x,y,z): ", quat_torque.w, quat_torque.x, quat_torque.y, quat_torque.z);
+		#endif
+
+		// Converting quaternion gradients into orientation gradients 
+		// Derived from autodockdev/motion.py/_get_cube3_gradient
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		printf("\n%s\n", "----------------------------------------------------------");
+		printf("%-30s %-10.6f %-10.6f %-10.6f %-10.6f\n", "current_q (w,x,y,z): ", genrot_unitvec.w, genrot_unitvec.x, genrot_unitvec.y, genrot_unitvec.z);
+		#endif
+
+		// This is where we want to be in quaternion space
+		// target_q = rotation.q_mult(q, current_q)
+		float4 target_q = quaternion_multiply(quat_torque, genrot_unitvec);
+
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		printf("\n%s\n", "----------------------------------------------------------");
+		printf("%-30s %-10.6f %-10.6f %-10.6f %-10.6f\n", "target_q (w,x,y,z): ", target_q.w, target_q.x, target_q.y, target_q.z);
+		#endif
+
+		// This is where we are in the orientation axis-angle space
+		// Equivalent to "current_oclacube" in autodockdev/motions.py
+		float current_phi      = fmod_pi2(PI_TIMES_2 + phi);
+		float current_theta    = fmod_pi2(PI_TIMES_2 + theta);
+		float current_rotangle = fmod_pi2(PI_TIMES_2 + genrotangle);
+
+		// This is where we want to be in the orientation axis-angle space
+		float target_phi, target_theta, target_rotangle;
+
+		// target_oclacube = quaternion_to_oclacube(target_q, theta_larger_than_pi)
+		// Derived from autodockdev/motions.py/quaternion_to_oclacube()
+		// In our terms means quaternion_to_oclacube(target_q{w|x|y|z}, theta_larger_than_pi)
+		target_rotangle = 2.0f * acos(target_q.w); // = 2.0f * ang;
+		float sin_ang = sqrt(1.0f-target_q.w*target_q.w); // = native_sin(ang);
+
+		target_theta = PI_TIMES_2 + is_theta_gt_pi * acos(target_q.z / sin_ang );
+		target_phi   = fmod_pi2((atan2( is_theta_gt_pi*target_q.y, is_theta_gt_pi*target_q.x) + PI_TIMES_2));
+
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		printf("\n%s\n", "----------------------------------------------------------");
+		printf("%-30s %-10.6f %-10.6f %-10.6f\n", "target_axisangle (1,2,3): ", target_phi, target_theta, target_rotangle);
+		#endif
+		
+		// The infinitesimal rotation will produce an infinitesimal displacement
+		// in shoemake space. This is to guarantee that the direction of
+		// the displacement in shoemake space is not distorted.
+		// The correct amount of displacement in shoemake space is obtained
+		// by multiplying the infinitesimal displacement by shoemake_scaling:
+		//float shoemake_scaling = native_divide(torque_length, INFINITESIMAL_RADIAN/*infinitesimal_radian*/);
+		float orientation_scaling = torque_length * INV_INFINITESIMAL_RADIAN;
+
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		printf("\n%s\n", "----------------------------------------------------------");
+		printf("%-30s %-10.6f\n", "orientation_scaling: ", orientation_scaling);
+		#endif
+
+		// Derivates in cube3
+		float grad_phi, grad_theta, grad_rotangle;
+		grad_phi      = orientation_scaling * (fmod_pi2(target_phi      - current_phi      + PI_FLOAT) - PI_FLOAT);
+		grad_theta    = orientation_scaling * (fmod_pi2(target_theta    - current_theta    + PI_FLOAT) - PI_FLOAT);
+		grad_rotangle = orientation_scaling * (fmod_pi2(target_rotangle - current_rotangle + PI_FLOAT) - PI_FLOAT);
+
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		printf("\n%s\n", "----------------------------------------------------------");
+		printf("%-30s \n", "grad_axisangle (1,2,3) - before empirical scaling: ");
+		printf("%-13s %-13s %-13s \n", "grad_phi", "grad_theta", "grad_rotangle");
+		printf("%-13.6f %-13.6f %-13.6f\n", grad_phi, grad_theta, grad_rotangle);
+		#endif
+
+		// Correcting theta gradients interpolating 
+		// values from correction look-up-tables
+		// (X0,Y0) and (X1,Y1) are known points
+		// How to find the Y value in the straight line between Y0 and Y1,
+		// corresponding to a certain X?
+		/*
+			| dependence_on_theta_const
+			| dependence_on_rotangle_const
+			|
+			|
+			|                        Y1
+			|
+			|             Y=?
+			|    Y0   
+			|_________________________________ angle_const
+			     X0  	X	 X1
+		*/
+
+		// Finding the index-position of "grad_delta" in the "angle_const" array
+		//uint index_theta    = floor(native_divide(current_theta    - angle_const[0], angle_delta));
+		//uint index_rotangle = floor(native_divide(current_rotangle - angle_const[0], angle_delta));
+		uint index_theta    = floor((current_theta    - cData.mem_angle_const[0]) * inv_angle_delta);
+		uint index_rotangle = floor((current_rotangle - cData.mem_angle_const[0]) * inv_angle_delta);
+
+		// Interpolating theta values
+		// X0 -> index - 1
+		// X1 -> index + 1
+		// Expresed as weighted average:
+		// Y = [Y0 * ((X1 - X) / (X1-X0))] +  [Y1 * ((X - X0) / (X1-X0))]
+		// Simplified for GPU (less terms):
+		// Y = [Y0 * (X1 - X) + Y1 * (X - X0)] / (X1 - X0)
+		// Taking advantage of constant:
+		// Y = [Y0 * (X1 - X) + Y1 * (X - X0)] * inv_angle_delta
+
+		float X0, Y0;
+		float X1, Y1;
+		float dependence_on_theta;  	//Y = dependence_on_theta
+
+		// Using interpolation on out-of-bounds elements results in hang
+		if ((index_theta <= 0) || (index_theta >= 999))
+		{
+			dependence_on_theta = cData.mem_dependence_on_theta_const[stick_to_bounds(index_theta,0,999)];
+		} else
+		{
+			X0 = cData.mem_angle_const[index_theta];
+			X1 = cData.mem_angle_const[index_theta+1];
+			Y0 = cData.mem_dependence_on_theta_const[index_theta];
+			Y1 = cData.mem_dependence_on_theta_const[index_theta+1];
+			dependence_on_theta = (Y0 * (X1-current_theta) + Y1 * (current_theta-X0)) * inv_angle_delta;
+		}
+		
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		printf("\n%s\n", "----------------------------------------------------------");
+		printf("%-30s %-10.6f\n", "dependence_on_theta: ", dependence_on_theta);
+		#endif
+
+		// Interpolating rotangle values
+		float dependence_on_rotangle; 	//Y = dependence_on_rotangle
+		// Using interpolation on previous and/or next elements results in hang
+		// Using interpolation on out-of-bounds elements results in hang
+		if ((index_rotangle <= 0) || (index_rotangle >= 999))
+		{
+			dependence_on_rotangle = cData.mem_dependence_on_rotangle_const[stick_to_bounds(index_rotangle,0,999)];
+		} else
+		{
+			X0 = cData.mem_angle_const[index_rotangle];
+			X1 = cData.mem_angle_const[index_rotangle+1];
+			Y0 = cData.mem_dependence_on_rotangle_const[index_rotangle];
+			Y1 = cData.mem_dependence_on_rotangle_const[index_rotangle+1];
+			dependence_on_rotangle = (Y0 * (X1-current_rotangle) + Y1 * (current_rotangle-X0)) * inv_angle_delta;
+		}
+
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		printf("\n%s\n", "----------------------------------------------------------");
+		printf("%-30s %-10.6f\n", "dependence_on_rotangle: ", dependence_on_rotangle);
+		#endif
+
+		// Setting gradient rotation-related genotypes in cube
+		// Multiplicating by DEG_TO_RAD is to make it uniform to DEG (see torsion gradients)
+		gradient_genotype[3] = (grad_phi / (dependence_on_theta * dependence_on_rotangle))  * DEG_TO_RAD;
+		gradient_genotype[4] = (grad_theta / dependence_on_rotangle)			* DEG_TO_RAD; 
+		gradient_genotype[5] = grad_rotangle                                                            * DEG_TO_RAD;
+		#if defined (PRINT_GRAD_ROTATION_GENES)
+		printf("\n%s\n", "----------------------------------------------------------");
+		printf("%-30s \n", "grad_axisangle (1,2,3) - after empirical scaling: ");
+		printf("%-13s %-13s %-13s \n", "grad_phi", "grad_theta", "grad_rotangle");
+		printf("%-13.6f %-13.6f %-13.6f\n", gradient_genotype[3], gradient_genotype[4], gradient_genotype[5]);
+		#endif
+	}
+    __threadfence();
+    __syncthreads();
+
+	// ------------------------------------------
+	// Obtaining torsion-related gradients
+	// ------------------------------------------
+	uint32_t num_torsion_genes = cData.dockpars.num_of_genes-6;
+	for (uint32_t idx = threadIdx.x;
+		  idx < num_torsion_genes * cData.dockpars.num_of_atoms;
+		  idx += blockDim.x) {
+
+		uint32_t rotable_atom_cnt = idx / num_torsion_genes;
+		uint32_t rotbond_id = idx - rotable_atom_cnt * num_torsion_genes; // this is a bit cheaper than % (modulo)
+
+		if (rotable_atom_cnt >= cData.mem_num_rotating_atoms_per_rotbond_const[rotbond_id])
+			continue; // Nothing to do
+
+		// Querying ids of atoms belonging to the rotatable bond in question
+		int atom1_id = cData.mem_rotbonds_const[2*rotbond_id];
+		int atom2_id = cData.mem_rotbonds_const[2*rotbond_id+1];
+
+		float4 atomRef_coords;
+		atomRef_coords = calc_coords[atom1_id];
+		float4 rotation_unitvec;
+        rotation_unitvec.x = calc_coords[atom2_id].x - atomRef_coords.x;
+        rotation_unitvec.y = calc_coords[atom2_id].y - atomRef_coords.y;
+        rotation_unitvec.z = calc_coords[atom2_id].z - atomRef_coords.z;
+        rotation_unitvec.w = calc_coords[atom2_id].w - atomRef_coords.w;
+        float l = 1.0f / norm4d(rotation_unitvec.x, rotation_unitvec.y, rotation_unitvec.z, rotation_unitvec.w);
+        rotation_unitvec.x *= l;
+        rotation_unitvec.y *= l;
+        rotation_unitvec.z *= l;
+        rotation_unitvec.w *= l;
+
+		// Torque of torsions
+		uint lig_atom_id = cData.mem_rotbonds_atoms_const[MAX_NUM_OF_ATOMS*rotbond_id + rotable_atom_cnt];
+		float4 torque_tor, r, atom_force;
+
+		// Calculating torque on point "A" 
+		// They are converted back to Angstroms here
+		r.x = (calc_coords[lig_atom_id].x - atomRef_coords.x);
+        r.y = (calc_coords[lig_atom_id].y - atomRef_coords.y);
+        r.z = (calc_coords[lig_atom_id].z - atomRef_coords.z);
+        r.w = (calc_coords[lig_atom_id].w - atomRef_coords.w);
+
+		// Re-using "gradient_inter_*" for total gradient (inter+intra)
+		atom_force.x = gradient_inter_x[lig_atom_id]; 
+		atom_force.y = gradient_inter_y[lig_atom_id];
+		atom_force.z = gradient_inter_z[lig_atom_id];
+		atom_force.w = 0.0f;
+
+		torque_tor = cross(r, atom_force);
+        float torque_on_axis = (rotation_unitvec.x * torque_tor.x +
+                                rotation_unitvec.y * torque_tor.y +
+                                rotation_unitvec.z * torque_tor.z +
+                                rotation_unitvec.w * torque_tor.w) * cData.dockpars.grid_spacing;
+
+		// Assignment of gene-based gradient
+		// - this works because a * (a_1 + a_2 + ... + a_n) = a*a_1 + a*a_2 + ... + a*a_n
+		ATOMICADDF32(&gradient_genotype[rotbond_id+6], torque_on_axis * DEG_TO_RAD); /*(M_PI / 180.0f)*/;
+	}
+    __threadfence();
+	__syncthreads();
+
+	#if defined (CONVERT_INTO_ANGSTROM_RADIAN)
+	for (uint32_t gene_cnt = threadIdx.x+3; // Only for gene_cnt > 2 means start gene_cnt at 3
+		  gene_cnt < cData.dockpars.num_of_genes;
+		  gene_cnt+= blockDim.x) {
+		gradient_genotype[gene_cnt] *= SCFACTOR_ANGSTROM_RADIAN;
+	}
+	__threadfence();
+    __syncthreads();
+	#endif
+}

--- a/cuda/calcenergy.cu
+++ b/cuda/calcenergy.cu
@@ -219,6 +219,7 @@ __device__ void gpu_calc_energy(
         __syncthreads();
 
 	} // End rotation_counter for-loop
+    return;
 
 	// ================================================
 	// CALCULATING INTERMOLECULAR ENERGY

--- a/cuda/calcenergy.cu
+++ b/cuda/calcenergy.cu
@@ -295,7 +295,7 @@ __device__ void gpu_calc_energy(
 	} // End atom_id for-loop (INTERMOLECULAR ENERGY)
 
 #if defined (DEBUG_ENERGY_KERNEL)
-    REDUCEFLOATSUM(interE. pAccumulator)
+    REDUCEFLOATSUM(interE, pAccumulator)
 #endif
 
 	// In paper: intermolecular and internal energy calculation

--- a/cuda/calcenergy.cu
+++ b/cuda/calcenergy.cu
@@ -219,7 +219,6 @@ __device__ void gpu_calc_energy(
         __syncthreads();
 
 	} // End rotation_counter for-loop
-    return;
 
 	// ================================================
 	// CALCULATING INTERMOLECULAR ENERGY
@@ -263,7 +262,7 @@ __device__ void gpu_calc_energy(
 		weights [idx_111] = dx*dy*dz;
 
 		// Grid value at 000
-		float* grid_value_000 = cData.dockpars.fgrids + ((x_low  + y_low*g1  + z_low*g2)<<2);
+		float* grid_value_000 = cData.pMem_fgrids + ((x_low  + y_low*g1  + z_low*g2)<<2);
 		ulong mul_tmp = atom_typeid*g3<<2;
 		// Calculating affinity energy
 		energy += TRILININTERPOL((grid_value_000+mul_tmp), weights);

--- a/cuda/calcenergy.cu
+++ b/cuda/calcenergy.cu
@@ -384,7 +384,7 @@ __device__ void gpu_calc_energy(
 		} // if cuttoff1 - internuclear-distance at 8A
 
 		// Calculating energy contributions
-		// Cuttoff2: internuclear-distance at 20.48A only for el and sol.
+		// Cutoff2: internuclear-distance at 20.48A only for el and sol.
 		if (atomic_distance < 20.48f)
 		{
 			float q1 = cData.pKerconst_interintra->atom_charges_const[atom1_id];

--- a/cuda/calcenergy.cu
+++ b/cuda/calcenergy.cu
@@ -83,7 +83,7 @@ __forceinline__ __device__ float4 quaternion_rotate(float4 v, float4 rot)
     result.x = v.x + z.x * rot.w + c.x;
     result.y = v.y + z.y * rot.w + c.y;    
     result.z = v.z + z.z * rot.w + c.z;
-    result.w = v.w + z.w * rot.w + c.w;    	
+    result.w = 0.0f;	
 	return result;
 }
 
@@ -179,14 +179,12 @@ __device__ void gpu_calc_energy(
                 rotation_movingvec.x = cData.pKerconst_conform->rotbonds_moving_vectors_const[3*rotbond_id];
                 rotation_movingvec.y = cData.pKerconst_conform->rotbonds_moving_vectors_const[3*rotbond_id+1];
                 rotation_movingvec.z = cData.pKerconst_conform->rotbonds_moving_vectors_const[3*rotbond_id+2];
-                rotation_movingvec.w = 0.0f;
                 
 				// Performing additionally the first movement which
 				// is needed only if rotating around rotatable bond
 				atom_to_rotate.x -= rotation_movingvec.x;
 				atom_to_rotate.y -= rotation_movingvec.y;
 				atom_to_rotate.z -= rotation_movingvec.z;
-				atom_to_rotate.w -= rotation_movingvec.w;                                
 			}
 
 			float4 quatrot_left = rotation_unitvec;
@@ -211,7 +209,6 @@ __device__ void gpu_calc_energy(
 			calc_coords[atom_id].x = qt.x + rotation_movingvec.x;
 			calc_coords[atom_id].y = qt.y + rotation_movingvec.y;
 			calc_coords[atom_id].z = qt.z + rotation_movingvec.z;            
-			calc_coords[atom_id].w = qt.w + rotation_movingvec.w;
 
 		} // End if-statement not dummy rotation
 

--- a/cuda/calcenergy.cu
+++ b/cuda/calcenergy.cu
@@ -94,7 +94,7 @@ __device__ void gpu_calc_energy(
     float& energy,
     int& run_id,
     float4* calc_coords,  
-    unsigned long long int* pAccumulator
+    long long int* pAccumulator
 ) 
 
 //The GPU device function calculates the energy of the entity described by genotype, dockpars and the liganddata
@@ -208,8 +208,7 @@ __device__ void gpu_calc_energy(
             float4 qt = quaternion_rotate(atom_to_rotate,quatrot_left);
 			calc_coords[atom_id].x = qt.x + rotation_movingvec.x;
 			calc_coords[atom_id].y = qt.y + rotation_movingvec.y;
-			calc_coords[atom_id].z = qt.z + rotation_movingvec.z;            
-
+			calc_coords[atom_id].z = qt.z + rotation_movingvec.z;
 		} // End if-statement not dummy rotation
 
         __threadfence();
@@ -353,11 +352,11 @@ __device__ void gpu_calc_energy(
 			if (atomic_distance >= (opt_distance + delta_distance)) {
 				smoothed_distance = atomic_distance - delta_distance;
 			}
+
 			// Calculating van der Waals / hydrogen bond term
 			uint idx = atom1_typeid * cData.dockpars.num_of_atypes + atom2_typeid;
 			energy +=   (cData.pKerconst_intra->VWpars_AC_const[idx] / pow(smoothed_distance,12)) -
                         (cData.pKerconst_intra->VWpars_BD_const[idx] / pow(smoothed_distance,6+4*hbond));
-
 
 			#if defined (DEBUG_ENERGY_KERNEL)
 			intraE +=   (cData.pKerconst_intra->VWpars_AC_const[idx] / pow(smoothed_distance,12)) -

--- a/cuda/calcenergy.cu
+++ b/cuda/calcenergy.cu
@@ -53,6 +53,16 @@ __forceinline__ __device__ float fast_acos(float cosine)
 	return copysign(ac,cosine) + (cosine<0.0f)*PI_FLOAT;
 }
 
+__forceinline__ __device__ float4 cross(float3& u, float3& v)
+{
+    float4 result;
+    result.x = u.y * v.z - v.y * u.z;
+    result.y = v.x * u.z - u.x * v.z;
+    result.z = u.x * v.y - v.x * u.y;
+    result.w = 0.0f;
+    return result;
+}
+
 __forceinline__ __device__ float4 cross(float4& u, float4& v)
 {
     float4 result;
@@ -87,13 +97,14 @@ __forceinline__ __device__ float4 quaternion_rotate(float4 v, float4 rot)
 	return result;
 }
 
+
 // All related pragmas are in defines.h (accesible by host and device code)
 
 __device__ void gpu_calc_energy(	    
     float* pGenotype,
     float& energy,
     int& run_id,
-    float4* calc_coords,  
+    float3* calc_coords,  
     float* pFloatAccumulator
 ) 
 
@@ -117,7 +128,6 @@ __device__ void gpu_calc_energy(
         calc_coords[atom_id].x = cData.pKerconst_conform->ref_coords_const[3*atom_id];
         calc_coords[atom_id].y = cData.pKerconst_conform->ref_coords_const[3*atom_id+1];
         calc_coords[atom_id].z = cData.pKerconst_conform->ref_coords_const[3*atom_id+2];
-        calc_coords[atom_id].w = 0.0f;
 	}
 
 	// General rotation moving vector
@@ -160,7 +170,11 @@ __device__ void gpu_calc_energy(
 			uint atom_id = rotation_list_element & RLIST_ATOMID_MASK;
 
 			// Capturing atom coordinates
-			float4 atom_to_rotate = calc_coords[atom_id];
+			float4 atom_to_rotate;
+            atom_to_rotate.x = calc_coords[atom_id].x;
+            atom_to_rotate.y = calc_coords[atom_id].y;
+            atom_to_rotate.z = calc_coords[atom_id].z;
+            atom_to_rotate.w = 0.0f;
 
 			// initialize with general rotation values
 			float4 rotation_unitvec = genrot_unitvec;

--- a/cuda/calcenergy.cu
+++ b/cuda/calcenergy.cu
@@ -1,0 +1,427 @@
+/*
+
+AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian Genetic Algorithm
+Copyright (C) 2017 TU Darmstadt, Embedded Systems and Applications Group, Germany. All rights reserved.
+For some of the code, Copyright (C) 2019 Computational Structural Biology Center, the Scripps Research Institute.
+
+AutoDock is a Trade Mark of the Scripps Research Institute.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+
+
+//#define DEBUG_ENERGY_KERNEL
+
+// No needed to be included as all kernel sources are stringified
+#define invpi2 1.0f/(PI_TIMES_2)
+
+__forceinline__ __device__ float fmod_pi2(float x)
+{
+	return x-(int)(invpi2*x)*PI_TIMES_2;
+}
+
+#define fast_acos_a  9.78056e-05f
+#define fast_acos_b -0.00104588f
+#define fast_acos_c  0.00418716f
+#define fast_acos_d -0.00314347f
+#define fast_acos_e  2.74084f
+#define fast_acos_f  0.370388f
+#define fast_acos_o -(fast_acos_a+fast_acos_b+fast_acos_c+fast_acos_d)
+
+__forceinline__ __device__ float fast_acos(float cosine)
+{
+	float x=fabs(cosine);
+	float x2=x*x;
+	float x3=x2*x;
+	float x4=x3*x;
+	float ac=(((fast_acos_o*x4+fast_acos_a)*x3+fast_acos_b)*x2+fast_acos_c)*x+fast_acos_d+
+		 fast_acos_e*sqrt(2.0f-sqrt(2.0f+2.0f*x))-fast_acos_f*sqrt(2.0f-2.0f*x);
+	return copysign(ac,cosine) + (cosine<0.0f)*PI_FLOAT;
+}
+
+__forceinline__ __device__ float4 cross(float4& u, float4& v)
+{
+    float4 result;
+    result.x = u.y * v.z - v.y * u.z;
+    result.y = v.x * u.z - u.x * v.z;
+    result.z = u.x * v.y - v.x * u.y;
+    result.w = 0.0f;
+    return result;
+}
+
+__forceinline__ __device__ float4 quaternion_multiply(float4 a, float4 b)
+{
+	float4 result = { a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y, // x
+			  a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x, // y
+			  a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w, // z
+			  a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z }; // w
+	return result;
+}
+__forceinline__ __device__ float4 quaternion_rotate(float4 v, float4 rot)
+{
+	float4 result;
+	
+	float4 z = cross(rot,v);
+    z.x *= 2.0f;
+    z.y *= 2.0f;
+    z.z *= 2.0f;
+    float4 c = cross(rot, z); 
+    result.x = v.x + z.x * rot.w + c.x;
+    result.y = v.y + z.y * rot.w + c.y;    
+    result.z = v.z + z.z * rot.w + c.z;
+    result.w = v.w + z.w * rot.w + c.w;    	
+	return result;
+}
+
+// All related pragmas are in defines.h (accesible by host and device code)
+
+__device__ void gpu_calc_energy(	    
+    float* pGenotype,
+    float& energy,
+    int& run_id,
+    float4* calc_coords,  
+    unsigned long long int* pAccumulator
+) 
+
+//The GPU device function calculates the energy of the entity described by genotype, dockpars and the liganddata
+//arrays in constant memory and returns it in the energy parameter. The parameter run_id has to be equal to the ID
+//of the run whose population includes the current entity (which can be determined with blockIdx.x), since this
+//determines which reference orientation should be used.
+{
+	energy = 0.0f;
+#if defined (DEBUG_ENERGY_KERNEL)    
+    float interE = 0.0f;
+    float intraE = 0.0f;
+#endif
+
+	// Initializing gradients (forces) 
+	// Derived from autodockdev/maps.py
+	for (uint atom_id = threadIdx.x;
+		  atom_id < cData.dockpars.num_of_atoms;
+		  atom_id+= blockDim.x) {
+		// Initialize coordinates
+        calc_coords[atom_id].x = cData.pKerconst_conform->ref_coords_const[3*atom_id];
+        calc_coords[atom_id].y = cData.pKerconst_conform->ref_coords_const[3*atom_id+1];
+        calc_coords[atom_id].z = cData.pKerconst_conform->ref_coords_const[3*atom_id+2];
+        calc_coords[atom_id].w = 0.0f;
+	}
+
+	// General rotation moving vector
+	float4 genrot_movingvec;
+	genrot_movingvec.x = pGenotype[0];
+	genrot_movingvec.y = pGenotype[1];
+	genrot_movingvec.z = pGenotype[2];
+	genrot_movingvec.w = 0.0f;
+	// Convert orientation genes from sex. to radians
+	float phi         = pGenotype[3] * DEG_TO_RAD;
+	float theta       = pGenotype[4] * DEG_TO_RAD;
+	float genrotangle = pGenotype[5] * DEG_TO_RAD;
+
+	float4 genrot_unitvec;
+	float sin_angle = sin(theta);
+	float s2 = sin(genrotangle * 0.5f);
+	genrot_unitvec.x = s2*sin_angle*cos(phi);
+	genrot_unitvec.y = s2*sin_angle*sin(phi);
+	genrot_unitvec.z = s2*cos(theta);
+	genrot_unitvec.w = cos(genrotangle*0.5f);
+
+	uint g1 = cData.dockpars.gridsize_x;
+	uint g2 = cData.dockpars.gridsize_x_times_y;
+	uint g3 = cData.dockpars.gridsize_x_times_y_times_z;
+
+    __threadfence();
+    __syncthreads();
+
+	// ================================================
+	// CALCULATING ATOMIC POSITIONS AFTER ROTATIONS
+	// ================================================
+	for (uint rotation_counter  = threadIdx.x;
+	          rotation_counter  < cData.dockpars.rotbondlist_length;
+	          rotation_counter += blockDim.x)
+	{
+		int rotation_list_element = cData.pKerconst_rotlist->rotlist_const[rotation_counter];
+
+		if ((rotation_list_element & RLIST_DUMMY_MASK) == 0)	// If not dummy rotation
+		{
+			uint atom_id = rotation_list_element & RLIST_ATOMID_MASK;
+
+			// Capturing atom coordinates
+			float4 atom_to_rotate = calc_coords[atom_id];
+
+			// initialize with general rotation values
+			float4 rotation_unitvec = genrot_unitvec;
+			float4 rotation_movingvec = genrot_movingvec;
+
+			if ((rotation_list_element & RLIST_GENROT_MASK) == 0) // If rotating around rotatable bond
+			{
+				uint rotbond_id = (rotation_list_element & RLIST_RBONDID_MASK) >> RLIST_RBONDID_SHIFT;
+
+				float rotation_angle = pGenotype[6+rotbond_id]*DEG_TO_RAD*0.5f;
+				float s = sin(rotation_angle);
+                rotation_unitvec.x = s*cData.pKerconst_conform->rotbonds_unit_vectors_const[3*rotbond_id];
+                rotation_unitvec.y = s*cData.pKerconst_conform->rotbonds_unit_vectors_const[3*rotbond_id+1];
+                rotation_unitvec.z = s*cData.pKerconst_conform->rotbonds_unit_vectors_const[3*rotbond_id+2];
+                rotation_unitvec.w = cos(rotation_angle);
+                rotation_movingvec.x = cData.pKerconst_conform->rotbonds_moving_vectors_const[3*rotbond_id];
+                rotation_movingvec.y = cData.pKerconst_conform->rotbonds_moving_vectors_const[3*rotbond_id+1];
+                rotation_movingvec.z = cData.pKerconst_conform->rotbonds_moving_vectors_const[3*rotbond_id+2];
+                rotation_movingvec.w = 0.0f;
+                
+				// Performing additionally the first movement which
+				// is needed only if rotating around rotatable bond
+				atom_to_rotate.x -= rotation_movingvec.x;
+				atom_to_rotate.y -= rotation_movingvec.y;
+				atom_to_rotate.z -= rotation_movingvec.z;
+				atom_to_rotate.w -= rotation_movingvec.w;                                
+			}
+
+			float4 quatrot_left = rotation_unitvec;
+			// Performing rotation
+			if ((rotation_list_element & RLIST_GENROT_MASK) != 0)	// If general rotation,
+										// two rotations should be performed
+										// (multiplying the quaternions)
+			{
+				// Calculating quatrot_left*ref_orientation_quats_const,
+				// which means that reference orientation rotation is the first
+				uint rid4 = 4 * run_id;
+                float4 qt;
+                qt.x = cData.pKerconst_conform->ref_orientation_quats_const[rid4+0];
+                qt.y = cData.pKerconst_conform->ref_orientation_quats_const[rid4+1];
+                qt.z = cData.pKerconst_conform->ref_orientation_quats_const[rid4+2];
+                qt.w = cData.pKerconst_conform->ref_orientation_quats_const[rid4+3];
+				quatrot_left = quaternion_multiply(quatrot_left, qt);
+			}
+
+			// Performing final movement and storing values
+            float4 qt = quaternion_rotate(atom_to_rotate,quatrot_left);
+			calc_coords[atom_id].x = qt.x + rotation_movingvec.x;
+			calc_coords[atom_id].y = qt.y + rotation_movingvec.y;
+			calc_coords[atom_id].z = qt.z + rotation_movingvec.z;            
+			calc_coords[atom_id].w = qt.w + rotation_movingvec.w;
+
+		} // End if-statement not dummy rotation
+
+        __threadfence();
+        __syncthreads();
+
+	} // End rotation_counter for-loop
+
+	// ================================================
+	// CALCULATING INTERMOLECULAR ENERGY
+	// ================================================
+	for (uint atom_id = threadIdx.x;
+	          atom_id < cData.dockpars.num_of_atoms;
+	          atom_id+= blockDim.x)
+	{
+		uint atom_typeid = cData.pKerconst_interintra->atom_types_const[atom_id];
+		float x = calc_coords[atom_id].x;
+		float y = calc_coords[atom_id].y;
+		float z = calc_coords[atom_id].z;
+		float q = cData.pKerconst_interintra->atom_charges_const[atom_id];
+		if ((x < 0) || (y < 0) || (z < 0) || (x >= cData.dockpars.gridsize_x-1)
+				                  || (y >= cData.dockpars.gridsize_y-1)
+						  || (z >= cData.dockpars.gridsize_z-1)){
+			energy += 16777216.0f; //100000.0f;
+			continue; // get on with loop as our work here is done (we crashed into the walls)
+		}
+		// Getting coordinates
+		uint x_low  = (uint)floor(x); 
+		uint y_low  = (uint)floor(y); 
+		uint z_low  = (uint)floor(z);
+
+		float dx = x - x_low;
+		float omdx = 1.0 - dx;
+		float dy = y - y_low; 
+		float omdy = 1.0 - dy;
+		float dz = z - z_low;
+		float omdz = 1.0 - dz;
+
+		// Calculating interpolation weights
+		float weights[8];
+		weights [idx_000] = omdx*omdy*omdz;
+		weights [idx_100] = dx*omdy*omdz;
+		weights [idx_010] = omdx*dy*omdz;
+		weights [idx_110] = dx*dy*omdz;
+		weights [idx_001] = omdx*omdy*dz;
+		weights [idx_101] = dx*omdy*dz;
+		weights [idx_011] = omdx*dy*dz;
+		weights [idx_111] = dx*dy*dz;
+
+		// Grid value at 000
+		float* grid_value_000 = cData.dockpars.fgrids + ((x_low  + y_low*g1  + z_low*g2)<<2);
+		ulong mul_tmp = atom_typeid*g3<<2;
+		// Calculating affinity energy
+		energy += TRILININTERPOL((grid_value_000+mul_tmp), weights);
+
+		#if defined (DEBUG_ENERGY_KERNEL)
+		interE += TRILININTERPOL((grid_value_000+mul_tmp), weights);
+		#endif
+
+		// Capturing electrostatic values
+		atom_typeid = cData.dockpars.num_of_atypes;
+
+		mul_tmp = atom_typeid*g3<<2;
+		// Calculating electrostatic energy
+		energy += q * TRILININTERPOL((grid_value_000+mul_tmp), weights);
+
+		#if defined (DEBUG_ENERGY_KERNEL)
+		interE += q * TRILININTERPOL((grid_value_000+mul_tmp), weights);
+		#endif
+
+		// Capturing desolvation values
+		atom_typeid = cData.dockpars.num_of_atypes+1;
+
+		mul_tmp = atom_typeid*g3<<2;
+		// Calculating desolvation energy
+		energy += fabs(q) * TRILININTERPOL((grid_value_000+mul_tmp), weights);
+
+		#if defined (DEBUG_ENERGY_KERNEL)
+		interE += fabs(q) * TRILININTERPOL((grid_value_000+mul_tmp), weights);
+		#endif
+	} // End atom_id for-loop (INTERMOLECULAR ENERGY)
+
+#if defined (DEBUG_ENERGY_KERNEL)
+    REDUCEFLOATSUM(interE. pAccumulator)
+#endif
+
+	// In paper: intermolecular and internal energy calculation
+	// are independent from each other, -> NO BARRIER NEEDED
+	// but require different operations,
+	// thus, they can be executed only sequentially on the GPU.
+	float delta_distance = 0.5f * cData.dockpars.smooth; 
+
+	// ================================================
+	// CALCULATING INTRAMOLECULAR ENERGY
+	// ================================================
+	for (uint contributor_counter = threadIdx.x;
+	          contributor_counter < cData.dockpars.num_of_intraE_contributors;
+	          contributor_counter += blockDim.x)
+
+	{
+
+		// Getting atom IDs
+		uint atom1_id = cData.pKerconst_intracontrib->intraE_contributors_const[3*contributor_counter];
+		uint atom2_id = cData.pKerconst_intracontrib->intraE_contributors_const[3*contributor_counter+1];
+		uint hbond = (uint)(cData.pKerconst_intracontrib->intraE_contributors_const[3*contributor_counter+2] == 1);	// evaluates to 1 in case of H-bond, 0 otherwise
+
+		// Calculating vector components of vector going
+		// from first atom's to second atom's coordinates
+		float subx = calc_coords[atom1_id].x - calc_coords[atom2_id].x;
+		float suby = calc_coords[atom1_id].y - calc_coords[atom2_id].y;
+		float subz = calc_coords[atom1_id].z - calc_coords[atom2_id].z;
+
+		// Calculating atomic_distance
+		float atomic_distance = sqrt(subx*subx + suby*suby + subz*subz)*cData.dockpars.grid_spacing;
+
+		// Getting type IDs
+		uint atom1_typeid = cData.pKerconst_interintra->atom_types_const[atom1_id];
+		uint atom2_typeid = cData.pKerconst_interintra->atom_types_const[atom2_id];
+
+		uint atom1_type_vdw_hb = cData.pKerconst_intra->atom1_types_reqm_const [atom1_typeid];
+		uint atom2_type_vdw_hb = cData.pKerconst_intra->atom2_types_reqm_const [atom2_typeid];
+
+
+		// Calculating energy contributions
+		// Cuttoff1: internuclear-distance at 8A only for vdw and hbond.
+		if (atomic_distance < 8.0f)
+		{
+			// Getting optimum pair distance (opt_distance) from reqm and reqm_hbond
+			// reqm: equilibrium internuclear separation 
+			//       (sum of the vdW radii of two like atoms (A)) in the case of vdW
+			// reqm_hbond: equilibrium internuclear separation
+			//  	 (sum of the vdW radii of two like atoms (A)) in the case of hbond 
+			float opt_distance = (cData.pKerconst_intra->reqm_const [atom1_type_vdw_hb+ATYPE_NUM*hbond] + cData.pKerconst_intra->reqm_const [atom2_type_vdw_hb+ATYPE_NUM*hbond]);
+
+			// Getting smoothed distance
+			// smoothed_distance = function(atomic_distance, opt_distance)
+			float smoothed_distance = opt_distance;
+
+			if (atomic_distance <= (opt_distance - delta_distance)) {
+				smoothed_distance = atomic_distance + delta_distance;
+			}
+			if (atomic_distance >= (opt_distance + delta_distance)) {
+				smoothed_distance = atomic_distance - delta_distance;
+			}
+			// Calculating van der Waals / hydrogen bond term
+			uint idx = atom1_typeid * cData.dockpars.num_of_atypes + atom2_typeid;
+			energy +=   (cData.pKerconst_intra->VWpars_AC_const[idx] / pow(smoothed_distance,12)) -
+                        (cData.pKerconst_intra->VWpars_BD_const[idx] / pow(smoothed_distance,6+4*hbond));
+
+
+			#if defined (DEBUG_ENERGY_KERNEL)
+			intraE +=   (cData.pKerconst_intra->VWpars_AC_const[idx] / pow(smoothed_distance,12)) -
+                        (cData.pKerconst_intra->VWpars_BD_const[idx] / pow(smoothed_distance,6+4*hbond));
+			#endif
+		} // if cuttoff1 - internuclear-distance at 8A
+
+		// Calculating energy contributions
+		// Cuttoff2: internuclear-distance at 20.48A only for el and sol.
+		if (atomic_distance < 20.48f)
+		{
+			float q1 = cData.pKerconst_interintra->atom_charges_const[atom1_id];
+			float q2 = cData.pKerconst_interintra->atom_charges_const[atom2_id];
+			float dist2 = atomic_distance*atomic_distance;
+			// Calculating desolvation term
+			float desolv_energy =  ((cData.pKerconst_intra->dspars_S_const[atom1_typeid] +
+						 cData.dockpars.qasp*fabs(q1)) * cData.pKerconst_intra->dspars_V_const[atom2_typeid] +
+						(cData.pKerconst_intra->dspars_S_const[atom2_typeid] +
+						 cData.dockpars.qasp*fabs(q2)) * cData.pKerconst_intra->dspars_V_const[atom1_typeid]) *
+						(cData.dockpars.coeff_desolv*(12.96f-0.1063f*dist2*(1.0f-0.001947f*dist2)) / 
+                        (12.96f+dist2*(0.4137f+dist2*(0.00357f+0.000112f*dist2))) // *native_exp(-0.03858025f*atomic_distance*atomic_distance);
+							      );
+			// Calculating electrostatic term
+			float dist_shift=atomic_distance+1.261f;
+			dist2=dist_shift*dist_shift;
+			float diel = (1.105f / dist2)+0.0104f;
+			float es_energy = cData.dockpars.coeff_elec * q1 * q2 / atomic_distance;
+			energy += diel * es_energy + desolv_energy;
+
+			#if defined (DEBUG_ENERGY_KERNEL)
+			intraE += (cData.dockpars.coeff_elec * q1 * q2) /
+                      (atomic_distance * (DIEL_A + (DIEL_B / (1.0f + DIEL_K*native_exp(-DIEL_B_TIMES_H*atomic_distance))))) +
+						((cData.pKerconst_intra->dspars_S_const[atom1_typeid] +
+						  cData.dockpars.qasp*fabs(q1)) * cData.pKerconst_intra->dspars_V_const[atom2_typeid] +
+						 (cData.pKerconst_intra->dspars_S_const[atom2_typeid] +
+						  cData.dockpars.qasp*fabs(q2))*cData.pKerconst_intra->dspars_V_const[atom1_typeid]) *
+							cData.dockpars.coeff_desolv*exp(-0.03858025f*pow(atomic_distance, 2));
+			#endif
+		} // if cuttoff2 - internuclear-distance at 20.48A
+
+		// ------------------------------------------------
+		// Required only for flexrings
+		// Checking if this is a CG-G0 atomic pair.
+		// If so, then adding energy term (E = G * distance).
+		// Initial specification required NON-SMOOTHED distance.
+		// This interaction is evaluated at any distance,
+		// so no cuttoffs considered here!
+		if (((atom1_type_vdw_hb == ATYPE_CG_IDX) && (atom2_type_vdw_hb == ATYPE_G0_IDX)) || 
+		    ((atom1_type_vdw_hb == ATYPE_G0_IDX) && (atom2_type_vdw_hb == ATYPE_CG_IDX))) 
+        {
+			energy += G * atomic_distance;
+		}
+		// ------------------------------------------------
+
+	} // End contributor_counter for-loop (INTRAMOLECULAR ENERGY)
+
+
+	// reduction to calculate energy
+    REDUCEFLOATSUM(energy, pAccumulator)
+#if defined (DEBUG_ENERGY_KERNEL)
+    REDUCEFLOATSUM(intraE, pAccumulator)
+#endif
+}
+

--- a/cuda/constants.h
+++ b/cuda/constants.h
@@ -1,0 +1,96 @@
+typedef struct
+{
+        int             num_of_atoms;
+        int             num_of_atypes;
+        int             num_of_intraE_contributors;
+        int             gridsize_x;
+        int             gridsize_y;
+        int             gridsize_z;
+        float           grid_spacing;
+        float*          fgrids;
+        int             rotbondlist_length;
+        float           coeff_elec;
+        float           coeff_desolv;
+        int*            evals_of_new_entities;
+        unsigned int*   prng_states;
+        int             pop_size;
+        int             num_of_genes;
+        float           tournament_rate;
+        float           crossover_rate;
+        float           mutation_rate;
+        float           abs_max_dmov;
+        float           abs_max_dang;
+        float           lsearch_rate;
+        float           smooth;
+        unsigned int    num_of_lsentities;
+        float           rho_lower_bound;
+        float           base_dmov_mul_sqrt3;
+        float           base_dang_mul_sqrt3;
+        unsigned int    cons_limit;
+        unsigned int    max_num_of_iters;
+        float           qasp;
+} GpuDockparameters;
+
+
+typedef struct
+{
+       float atom_charges_const[MAX_NUM_OF_ATOMS];
+       char  atom_types_const  [MAX_NUM_OF_ATOMS];
+} kernelconstant_interintra;
+
+typedef struct
+{
+       int  intraE_contributors_const[3*MAX_INTRAE_CONTRIBUTORS];
+} kernelconstant_intracontrib;
+
+typedef struct
+{
+       float reqm_const [2*ATYPE_NUM]; // 1st ATYPE_NUM entries = vdW, 2nd ATYPE_NUM entries = hbond
+       unsigned int  atom1_types_reqm_const [ATYPE_NUM];
+       unsigned int  atom2_types_reqm_const [ATYPE_NUM];
+       float VWpars_AC_const   [MAX_NUM_OF_ATYPES*MAX_NUM_OF_ATYPES];
+       float VWpars_BD_const   [MAX_NUM_OF_ATYPES*MAX_NUM_OF_ATYPES];
+       float dspars_S_const    [MAX_NUM_OF_ATYPES];
+       float dspars_V_const    [MAX_NUM_OF_ATYPES];
+} kernelconstant_intra;
+
+typedef struct
+{
+       int   rotlist_const     [MAX_NUM_OF_ROTATIONS];
+} kernelconstant_rotlist;
+
+typedef struct
+{
+       float ref_coords_const[3*MAX_NUM_OF_ATOMS];
+       float rotbonds_moving_vectors_const[3*MAX_NUM_OF_ROTBONDS];
+       float rotbonds_unit_vectors_const  [3*MAX_NUM_OF_ROTBONDS];
+       float ref_orientation_quats_const  [4*MAX_NUM_OF_RUNS];
+} kernelconstant_conform;
+
+
+struct GpuData {
+    GpuDockparameters               dockpars;
+    
+    // Consolidated constants and memory pointers to reduce kernel launch overhead
+    kernelconstant_interintra*      pKerConst_interintra;
+	kernelconstant_intracontrib*    pKerConst_intracontrib;
+	kernelconstant_intra*	        pKerConst_intra;
+	kernelconstant_rotlist*		    pKerConst_rotlist;
+	kernelconstant_conform*		    pKerConst_conform;
+	kernelconstant_grads*		    pKerConst_grads;
+    float*                          pMem_fgrids;
+    int*                            pMem_evals_of_new_entities;
+    int*                            pMem_gpu_evals_of_runs;
+    int*                            pMem_prng_states;
+    int                             mem_rotbonds_const[2*MAX_NUM_OF_ROTBONDS];
+    int                             mem_rotbonds_atoms_const[MAX_NUM_OF_ATOMS*MAX_NUM_OF_ROTBONDS];
+    int                             mem_num_rotating_atoms_per_rotbond_const[MAX_NUM_OF_ROTBONDS];
+    float                           mem_angle_const[1000];
+    float                           mem_dependence_on_theta_const[1000];
+    float                           mem_dependence_on_rotangle_const[1000];
+    
+    // CUDA-specific constants
+    unsigned int                    warpmask;
+};
+
+

--- a/cuda/kernel1.cu
+++ b/cuda/kernel1.cu
@@ -35,7 +35,7 @@ gpu_calc_initpop_kernel(
 	// and then passed to non-kernel functions.
 	__shared__ float4 calc_coords[MAX_NUM_OF_ATOMS];
     __shared__ unsigned long long int sAccumulator64;
-	float  energy;
+	float  energy = 0.0f;
 	int    run_id = blockIdx.x / cData.dockpars.pop_size;
     float* pGenotype = pMem_conformations_current + blockIdx.x * GENOTYPE_LENGTH_IN_GLOBMEM;
 
@@ -47,8 +47,7 @@ gpu_calc_initpop_kernel(
 			calc_coords,
             &sAccumulator64
 			);
-	// =============================================================
-    
+	// =============================================================  
 
     // Write out final energy
 	if (threadIdx.x == 0) 
@@ -61,5 +60,11 @@ gpu_calc_initpop_kernel(
 void gpu_calc_initpop(uint32_t blocks, uint32_t threadsPerBlock, float* pConformations_current, float* pEnergies_current)
 {
     gpu_calc_initpop_kernel<<<blocks, threadsPerBlock>>>(pConformations_current, pEnergies_current);
+    LAUNCHERROR("gpu_calc_initpop_kernel");
+    cudaError_t status;
+    status = cudaDeviceSynchronize();
+    RTERROR(status, "gpu_calc_initpop_kernel");
+    status = cudaDeviceReset();
+    RTERROR(status, "failed to shut down");
 }
 

--- a/cuda/kernel1.cu
+++ b/cuda/kernel1.cu
@@ -61,10 +61,13 @@ void gpu_calc_initpop(uint32_t blocks, uint32_t threadsPerBlock, float* pConform
 {
     gpu_calc_initpop_kernel<<<blocks, threadsPerBlock>>>(pConformations_current, pEnergies_current);
     LAUNCHERROR("gpu_calc_initpop_kernel");
+#if 0    
     cudaError_t status;
     status = cudaDeviceSynchronize();
     RTERROR(status, "gpu_calc_initpop_kernel");
     status = cudaDeviceReset();
     RTERROR(status, "failed to shut down");
+    exit(0);
+#endif
 }
 

--- a/cuda/kernel1.cu
+++ b/cuda/kernel1.cu
@@ -34,7 +34,7 @@ gpu_calc_initpop_kernel(
 	// These local variables must be declared in a kernel, 
 	// and then passed to non-kernel functions.
 	__shared__ float4 calc_coords[MAX_NUM_OF_ATOMS];
-    __shared__ long long int sAccumulator64;
+    __shared__ float sFloatAccumulator;
 	float  energy = 0.0f;
 	int    run_id = blockIdx.x / cData.dockpars.pop_size;
     float* pGenotype = pMem_conformations_current + blockIdx.x * GENOTYPE_LENGTH_IN_GLOBMEM;
@@ -45,7 +45,7 @@ gpu_calc_initpop_kernel(
 			energy,
 			run_id,
 			calc_coords,
-            &sAccumulator64
+            &sFloatAccumulator
 			);
 	// =============================================================  
 

--- a/cuda/kernel1.cu
+++ b/cuda/kernel1.cu
@@ -34,7 +34,7 @@ gpu_calc_initpop_kernel(
 	// These local variables must be declared in a kernel, 
 	// and then passed to non-kernel functions.
 	__shared__ float4 calc_coords[MAX_NUM_OF_ATOMS];
-    __shared__ unsigned long long int sAccumulator64;
+    __shared__ long long int sAccumulator64;
 	float  energy = 0.0f;
 	int    run_id = blockIdx.x / cData.dockpars.pop_size;
     float* pGenotype = pMem_conformations_current + blockIdx.x * GENOTYPE_LENGTH_IN_GLOBMEM;
@@ -61,7 +61,7 @@ void gpu_calc_initpop(uint32_t blocks, uint32_t threadsPerBlock, float* pConform
 {
     gpu_calc_initpop_kernel<<<blocks, threadsPerBlock>>>(pConformations_current, pEnergies_current);
     LAUNCHERROR("gpu_calc_initpop_kernel");
-#if 0    
+#if 0
     cudaError_t status;
     status = cudaDeviceSynchronize();
     RTERROR(status, "gpu_calc_initpop_kernel");

--- a/cuda/kernel1.cu
+++ b/cuda/kernel1.cu
@@ -33,7 +33,7 @@ gpu_calc_initpop_kernel(
 	// local variables within non-kernel functions.
 	// These local variables must be declared in a kernel, 
 	// and then passed to non-kernel functions.
-	__shared__ float4 calc_coords[MAX_NUM_OF_ATOMS];
+	__shared__ float3 calc_coords[MAX_NUM_OF_ATOMS];
     __shared__ float sFloatAccumulator;
 	float  energy = 0.0f;
 	int    run_id = blockIdx.x / cData.dockpars.pop_size;

--- a/cuda/kernel1.cu
+++ b/cuda/kernel1.cu
@@ -1,0 +1,65 @@
+/*
+
+AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian Genetic Algorithm
+Copyright (C) 2017 TU Darmstadt, Embedded Systems and Applications Group, Germany. All rights reserved.
+For some of the code, Copyright (C) 2019 Computational Structural Biology Center, the Scripps Research Institute.
+
+AutoDock is a Trade Mark of the Scripps Research Institute.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+__global__ void
+__launch_bounds__(NUM_OF_THREADS_PER_BLOCK, 1024 / NUM_OF_THREADS_PER_BLOCK)
+gpu_calc_initpop_kernel(	
+                float* pMem_conformations_current,
+                float* pMem_energies_current
+)
+{
+    // Some OpenCL compilers don't allow declaring 
+	// local variables within non-kernel functions.
+	// These local variables must be declared in a kernel, 
+	// and then passed to non-kernel functions.
+	__shared__ float4 calc_coords[MAX_NUM_OF_ATOMS];
+    __shared__ unsigned long long int sAccumulator64;
+	float  energy;
+	int    run_id = blockIdx.x / cData.dockpars.pop_size;
+    float* pGenotype = pMem_conformations_current + blockIdx.x * GENOTYPE_LENGTH_IN_GLOBMEM;
+
+	// =============================================================
+	gpu_calc_energy(
+            pGenotype,
+			energy,
+			run_id,
+			calc_coords,
+            &sAccumulator64
+			);
+	// =============================================================
+    
+
+    // Write out final energy
+	if (threadIdx.x == 0) 
+    {
+		pMem_energies_current[blockIdx.x] = energy;
+		cData.pMem_evals_of_new_entities[blockIdx.x] = 1;
+	}
+}
+
+void gpu_calc_initpop(uint32_t blocks, uint32_t threadsPerBlock, float* pConformations_current, float* pEnergies_current)
+{
+    gpu_calc_initpop_kernel<<<blocks, threadsPerBlock>>>(pConformations_current, pEnergies_current);
+}
+

--- a/cuda/kernel2.cu
+++ b/cuda/kernel2.cu
@@ -1,0 +1,58 @@
+/*
+
+AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian Genetic Algorithm
+Copyright (C) 2017 TU Darmstadt, Embedded Systems and Applications Group, Germany. All rights reserved.
+For some of the code, Copyright (C) 2019 Computational Structural Biology Center, the Scripps Research Institute.
+
+AutoDock is a Trade Mark of the Scripps Research Institute.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+
+
+
+__global__ void
+__launch_bounds__(NUM_OF_THREADS_PER_BLOCK, 1024 / NUM_OF_THREADS_PER_BLOCK)
+gpu_sum_evals_kernel()
+//The GPU global function sums the evaluation counter states
+//which are stored in evals_of_new_entities array foreach entity,
+//calculates the sums for each run and stores it in evals_of_runs array.
+//The number of blocks which should be started equals to num_of_runs,
+//since each block performs the summation for one run.
+{
+    
+    __shared__ int sSum_evals;
+	int partsum_evals = 0;
+    int* pEvals_of_new_entities = cData.pMem_evals_of_new_entities + blockIdx.x * cData.dockpars.pop_size;
+  	for (int entity_counter = threadIdx.x;
+	     entity_counter < cData.dockpars.pop_size;
+	     entity_counter += blockDim.x) 
+    {
+		partsum_evals += pEvals_of_new_entities[entity_counter];
+	}
+
+      
+    // Perform warp-wise reduction
+    REDUCEINTEGERSUM(partsum_evals, &sSum_evals);
+    if (threadIdx.x == 0)
+		cData.pMem_gpu_evals_of_runs[blockIdx.x] += sSum_evals;  
+}
+
+void gpu_sum_evals(uint32_t blocks, uint32_t threadsPerBlock)
+{
+    gpu_sum_evals_kernel<<<blocks, threadsPerBlock>>>();
+}

--- a/cuda/kernel2.cu
+++ b/cuda/kernel2.cu
@@ -55,5 +55,13 @@ gpu_sum_evals_kernel()
 void gpu_sum_evals(uint32_t blocks, uint32_t threadsPerBlock)
 {
     gpu_sum_evals_kernel<<<blocks, threadsPerBlock>>>();
-    LAUNCHERROR("gpu_sum_evals_kernel");    
+    LAUNCHERROR("gpu_sum_evals_kernel");
+#if 0
+    cudaError_t status;
+    status = cudaDeviceSynchronize();
+    RTERROR(status, "gpu_sum_evals_kernel");
+    status = cudaDeviceReset();
+    RTERROR(status, "failed to shut down");
+    exit(0);
+#endif
 }

--- a/cuda/kernel2.cu
+++ b/cuda/kernel2.cu
@@ -49,7 +49,9 @@ gpu_sum_evals_kernel()
     // Perform warp-wise reduction
     REDUCEINTEGERSUM(partsum_evals, &sSum_evals);
     if (threadIdx.x == 0)
-		cData.pMem_gpu_evals_of_runs[blockIdx.x] += sSum_evals;  
+    {
+        cData.pMem_gpu_evals_of_runs[blockIdx.x] += sSum_evals;
+    }
 }
 
 void gpu_sum_evals(uint32_t blocks, uint32_t threadsPerBlock)

--- a/cuda/kernel2.cu
+++ b/cuda/kernel2.cu
@@ -55,4 +55,5 @@ gpu_sum_evals_kernel()
 void gpu_sum_evals(uint32_t blocks, uint32_t threadsPerBlock)
 {
     gpu_sum_evals_kernel<<<blocks, threadsPerBlock>>>();
+    LAUNCHERROR("gpu_sum_evals_kernel");    
 }

--- a/cuda/kernel3.cu
+++ b/cuda/kernel3.cu
@@ -1,0 +1,308 @@
+/*
+
+AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian Genetic Algorithm
+Copyright (C) 2017 TU Darmstadt, Embedded Systems and Applications Group, Germany. All rights reserved.
+For some of the code, Copyright (C) 2019 Computational Structural Biology Center, the Scripps Research Institute.
+
+AutoDock is a Trade Mark of the Scripps Research Institute.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+
+
+
+
+__global__ void
+__launch_bounds__(NUM_OF_THREADS_PER_BLOCK, 1024 / NUM_OF_THREADS_PER_BLOCK)
+gpu_perform_LS_kernel(		
+            float* pMem_conformations_next,
+            float* pMem_energies_next
+
+)
+//The GPU global function performs local search on the pre-defined entities of conformations_next.
+//The number of blocks which should be started equals to num_of_lsentities*num_of_runs.
+//This way the first num_of_lsentities entity of each population will be subjected to local search
+//(and each block carries out the algorithm for one entity).
+//Since the first entity is always the best one in the current population,
+//it is always tested according to the ls probability, and if it not to be
+//subjected to local search, the entity with ID num_of_lsentities is selected instead of the first one (with ID 0).
+{
+	// Some OpenCL compilers don't allow declaring 
+	// local variables within non-kernel functions.
+	// These local variables must be declared in a kernel, 
+	// and then passed to non-kernel functions.
+	__shared__ float genotype_candidate[ACTUAL_GENOTYPE_LENGTH];
+	__shared__ float genotype_deviate  [ACTUAL_GENOTYPE_LENGTH];
+	__shared__ float genotype_bias     [ACTUAL_GENOTYPE_LENGTH];
+    __shared__ float rho;
+	__shared__ int   cons_succ;
+	__shared__ int   cons_fail;
+	__shared__ int   iteration_cnt;
+	__shared__ int   evaluation_cnt;
+	__shared__ float3 calc_coords[MAX_NUM_OF_ATOMS];
+	__shared__ float offspring_genotype[ACTUAL_GENOTYPE_LENGTH];
+	__shared__ float offspring_energy;
+    __shared__ float sFloatAccumulator;
+	__shared__ int entity_id;
+	float candidate_energy;
+    int run_id;
+
+	// Determining run ID and entity ID
+	// Initializing offspring genotype
+    run_id = blockIdx.x / cData.dockpars.num_of_lsentities;
+	if (threadIdx.x == 0)
+	{
+        entity_id = blockIdx.x % cData.dockpars.num_of_lsentities;
+
+		// Since entity 0 is the best one due to elitism,
+		// it should be subjected to random selection
+		if (entity_id == 0) {
+			// If entity 0 is not selected according to LS-rate,
+			// choosing an other entity
+			if (100.0f*gpu_randf(cData.pMem_prng_states) > cData.dockpars.lsearch_rate) {
+				entity_id = cData.dockpars.num_of_lsentities;					
+			}
+		}
+
+		offspring_energy = pMem_energies_next[run_id*cData.dockpars.pop_size+entity_id];
+		rho = 1.0f;
+		cons_succ = 0;
+		cons_fail = 0;
+		iteration_cnt = 0;
+		evaluation_cnt = 0;        
+	}
+    __threadfence();
+    __syncthreads();
+
+    size_t offset = (run_id * cData.dockpars.pop_size + entity_id) * GENOTYPE_LENGTH_IN_GLOBMEM;
+	for (uint32_t gene_counter = threadIdx.x;
+	     gene_counter < cData.dockpars.num_of_genes;
+	     gene_counter+= blockDim.x) {
+        offspring_genotype[gene_counter] = pMem_conformations_next[offset + gene_counter];
+		genotype_bias[gene_counter] = 0.0f;
+	}
+    __threadfence();
+	__syncthreads();
+    
+
+	while ((iteration_cnt < cData.dockpars.max_num_of_iters) && (rho > cData.dockpars.rho_lower_bound))
+	{
+		// New random deviate
+		for (uint32_t gene_counter = threadIdx.x;
+		     gene_counter < cData.dockpars.num_of_genes;
+		     gene_counter+= blockDim.x)
+		{
+			genotype_deviate[gene_counter] = rho*(2*gpu_randf(cData.pMem_prng_states)-1);
+
+			// Translation genes
+			if (gene_counter < 3) {
+				genotype_deviate[gene_counter] *= cData.dockpars.base_dmov_mul_sqrt3;
+			}
+			// Orientation and torsion genes
+			else {
+				genotype_deviate[gene_counter] *= cData.dockpars.base_dang_mul_sqrt3;
+			}
+		}
+
+		// Generating new genotype candidate
+		for (uint32_t gene_counter = threadIdx.x;
+		     gene_counter < cData.dockpars.num_of_genes;
+		     gene_counter+= blockDim.x) {
+			   genotype_candidate[gene_counter] = offspring_genotype[gene_counter] + 
+							      genotype_deviate[gene_counter]   + 
+							      genotype_bias[gene_counter];
+		}
+
+		// Evaluating candidate
+        __threadfence();
+        __syncthreads();
+
+		// ==================================================================
+		gpu_calc_energy(
+                genotype_candidate,
+                candidate_energy,
+                run_id,
+                calc_coords,
+                &sFloatAccumulator
+				);
+		// =================================================================
+
+		if (threadIdx.x == 0) {
+			evaluation_cnt++;
+		}
+        __threadfence();
+        __syncthreads();
+
+		if (candidate_energy < offspring_energy)	// If candidate is better, success
+		{
+			for (uint32_t gene_counter = threadIdx.x;
+			     gene_counter < cData.dockpars.num_of_genes;
+			     gene_counter+= blockDim.x)
+			{
+				// Updating offspring_genotype
+				offspring_genotype[gene_counter] = genotype_candidate[gene_counter];
+
+				// Updating genotype_bias
+				genotype_bias[gene_counter] = 0.6f*genotype_bias[gene_counter] + 0.4f*genotype_deviate[gene_counter];
+			}
+
+			// Work-item 0 will overwrite the shared variables
+			// used in the previous if condition
+			__threadfence();
+            __syncthreads();
+
+			if (threadIdx.x == 0)
+			{
+				offspring_energy = candidate_energy;
+				cons_succ++;
+				cons_fail = 0;
+			}
+		}
+		else	// If candidate is worser, check the opposite direction
+		{
+			// Generating the other genotype candidate
+			for (uint32_t gene_counter = threadIdx.x;
+			     gene_counter < cData.dockpars.num_of_genes;
+			     gene_counter+= blockDim.x) {
+				   genotype_candidate[gene_counter] = offspring_genotype[gene_counter] - 
+								      genotype_deviate[gene_counter] - 
+								      genotype_bias[gene_counter];
+			}
+
+			// Evaluating candidate
+			__threadfence();
+            __syncthreads();
+
+			// =================================================================
+			gpu_calc_energy(
+                genotype_candidate,
+                candidate_energy,
+                run_id,
+                calc_coords,
+                &sFloatAccumulator
+            );
+			// =================================================================
+
+			if (threadIdx.x == 0) {
+				evaluation_cnt++;
+
+				#if defined (DEBUG_ENERGY_KERNEL)
+				printf("%-18s [%-5s]---{%-5s}   [%-10.8f]---{%-10.8f}\n", "-ENERGY-KERNEL3-", "GRIDS", "INTRA", partial_interE[0], partial_intraE[0]);
+				#endif
+			}
+            __threadfence();
+            __syncthreads();
+
+			if (candidate_energy < offspring_energy) // If candidate is better, success
+			{
+				for (uint32_t gene_counter = threadIdx.x;
+				     gene_counter < cData.dockpars.num_of_genes;
+			       	     gene_counter+= blockDim.x)
+				{
+					// Updating offspring_genotype
+					offspring_genotype[gene_counter] = genotype_candidate[gene_counter];
+
+					// Updating genotype_bias
+					genotype_bias[gene_counter] = 0.6f*genotype_bias[gene_counter] - 0.4f*genotype_deviate[gene_counter];
+				}
+
+				// Work-item 0 will overwrite the shared variables
+				// used in the previous if condition
+                __threadfence();
+                __syncthreads();
+
+				if (threadIdx.x == 0)
+				{
+					offspring_energy = candidate_energy;
+					cons_succ++;
+					cons_fail = 0;
+				}
+			}
+			else	// Failure in both directions
+			{
+				for (uint32_t gene_counter = threadIdx.x;
+				     gene_counter < cData.dockpars.num_of_genes;
+				     gene_counter+= blockDim.x)
+					   // Updating genotype_bias
+					   genotype_bias[gene_counter] = 0.5f*genotype_bias[gene_counter];
+
+				if (threadIdx.x == 0)
+				{
+					cons_succ = 0;
+					cons_fail++;
+				}
+			}
+		}
+
+		// Changing rho if needed
+		if (threadIdx.x == 0)
+		{
+			iteration_cnt++;
+
+			if (cons_succ >= cData.dockpars.cons_limit)
+			{
+				rho *= LS_EXP_FACTOR;
+				cons_succ = 0;
+			}
+			else
+				if (cons_fail >= cData.dockpars.cons_limit)
+				{
+					rho *= LS_CONT_FACTOR;
+					cons_fail = 0;
+				}
+		}
+        __threadfence();
+        __syncthreads();
+	}
+
+	// Updating eval counter and energy
+	if (threadIdx.x == 0) {
+		cData.pMem_evals_of_new_entities[run_id*cData.dockpars.pop_size+entity_id] += evaluation_cnt;
+		pMem_energies_next[run_id*cData.dockpars.pop_size+entity_id] = offspring_energy;
+	}
+
+	// Mapping torsion angles and writing out results
+    offset = (run_id*cData.dockpars.pop_size+entity_id)*GENOTYPE_LENGTH_IN_GLOBMEM;
+	for (uint32_t gene_counter = threadIdx.x;
+	     gene_counter < cData.dockpars.num_of_genes;
+	     gene_counter+= blockDim.x) {
+        if (gene_counter >= 3) {
+		    map_angle(offspring_genotype[gene_counter]);
+		}
+        pMem_conformations_next[offset + gene_counter] = offspring_genotype[gene_counter];
+	}
+}
+
+
+void gpu_perform_LS(
+    uint32_t blocks,
+    uint32_t threads,
+    float* pMem_conformations_next,
+	float* pMem_energies_next
+)
+{
+    //size_t sz_shared = (9 * cpuData.dockpars.num_of_atoms + 5 * cpuData.dockpars.num_of_genes) * sizeof(float);
+    gpu_perform_LS_kernel<<<blocks, threads>>>(pMem_conformations_next, pMem_energies_next);
+    LAUNCHERROR("gpu_perform_LS_kernel");     
+#if 0
+    cudaError_t status;
+    status = cudaDeviceSynchronize();
+    RTERROR(status, "gpu_perform_LS_kernel");
+    status = cudaDeviceReset();
+    RTERROR(status, "failed to shut down");
+    exit(0);
+#endif
+}

--- a/cuda/kernel4.cu
+++ b/cuda/kernel4.cu
@@ -50,7 +50,7 @@ gpu_gen_and_eval_newpops_kernel(
 	__shared__ float randnums[10];
     __shared__ float sBestEnergy[32];
     __shared__ int sBestID[32];
-	__shared__ float4 calc_coords[MAX_NUM_OF_ATOMS];
+	__shared__ float3 calc_coords[MAX_NUM_OF_ATOMS];
     __shared__ float sFloatAccumulator;
 	int run_id;    
 	int temp_covr_point;

--- a/cuda/kernel4.cu
+++ b/cuda/kernel4.cu
@@ -51,7 +51,7 @@ gpu_gen_and_eval_newpops_kernel(
     __shared__ float sBestEnergy[32];
     __shared__ int sBestID[32];
 	__shared__ float4 calc_coords[MAX_NUM_OF_ATOMS];
-    __shared__ unsigned long long int sAccumulator;
+    __shared__ long long int sAccumulator;
 	int run_id;    
 	int temp_covr_point;
 	float energy;

--- a/cuda/kernel4.cu
+++ b/cuda/kernel4.cu
@@ -304,4 +304,5 @@ void gpu_gen_and_eval_newpops(
 )
 {
     gpu_gen_and_eval_newpops_kernel<<<blocks, threadsPerBlock>>>(pMem_conformations_current, pMem_energies_current, pMem_conformations_next, pMem_energies_next);
+    LAUNCHERROR("gpu_gen_and_eval_newpops_kernel");    
 }

--- a/cuda/kernel4.cu
+++ b/cuda/kernel4.cu
@@ -122,7 +122,7 @@ gpu_gen_and_eval_newpops_kernel(
         
         // Copy best genome to next generation
         int dOffset = blockIdx.x * GENOTYPE_LENGTH_IN_GLOBMEM;
-        int sOffset = (blockIdx.x + sBestID[0]) * GENOTYPE_LENGTH_IN_GLOBMEM;
+        int sOffset = sBestID[0] * GENOTYPE_LENGTH_IN_GLOBMEM;
         for (int i = threadIdx.x ; i < cData.dockpars.num_of_genes; i += blockDim.x)
         {
             pMem_conformations_next[dOffset + i] = pMem_conformations_current[sOffset + i];

--- a/cuda/kernel4.cu
+++ b/cuda/kernel4.cu
@@ -71,8 +71,8 @@ gpu_gen_and_eval_newpops_kernel(
             energy = 1000000000000.0f;
         }
         
-        // Scan through population
-        for (int i = blockIdx.x + blockDim.x; i < blockIdx.x + cData.dockpars.pop_size; i += blockDim.x)
+        // Scan through population (we already picked up a blockDim's worth above so skip)
+        for (int i = blockIdx.x + blockDim.x + threadIdx.x; i < blockIdx.x + cData.dockpars.pop_size; i += blockDim.x)
         {
             float e = pMem_energies_current[i];
             if (e < energy)
@@ -305,4 +305,11 @@ void gpu_gen_and_eval_newpops(
 {
     gpu_gen_and_eval_newpops_kernel<<<blocks, threadsPerBlock>>>(pMem_conformations_current, pMem_energies_current, pMem_conformations_next, pMem_energies_next);
     LAUNCHERROR("gpu_gen_and_eval_newpops_kernel");    
+#if 0 
+    cudaError_t status;
+    status = cudaDeviceSynchronize();
+    RTERROR(status, "gpu_gen_and_eval_newpops_kernel");
+    status = cudaDeviceReset();
+    RTERROR(status, "failed to shut down");
+#endif   
 }

--- a/cuda/kernel4.cu
+++ b/cuda/kernel4.cu
@@ -1,0 +1,307 @@
+/*
+
+AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian Genetic Algorithm
+Copyright (C) 2017 TU Darmstadt, Embedded Systems and Applications Group, Germany. All rights reserved.
+For some of the code, Copyright (C) 2019 Computational Structural Biology Center, the Scripps Research Institute.
+
+AutoDock is a Trade Mark of the Scripps Research Institute.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+
+
+
+
+//#define DEBUG_ENERGY_KERNEL4
+
+__global__ void
+__launch_bounds__(NUM_OF_THREADS_PER_BLOCK, 1024 / NUM_OF_THREADS_PER_BLOCK)
+gpu_gen_and_eval_newpops_kernel(
+    float* pMem_conformations_current,
+    float* pMem_energies_current,
+    float* pMem_conformations_next,
+    float* pMem_energies_next
+)
+//The GPU global function
+{
+	// Some OpenCL compilers don't allow declaring 
+	// local variables within non-kernel functions.
+	// These local variables must be declared in a kernel, 
+	// and then passed to non-kernel functions.
+	__shared__ float offspring_genotype[ACTUAL_GENOTYPE_LENGTH];
+	__shared__ int parent_candidates[4];
+	__shared__ float candidate_energies[4];
+	__shared__ int parents[2];
+	__shared__ int covr_point[2];
+	__shared__ float randnums[10];
+    __shared__ float sBestEnergy[32];
+    __shared__ int sBestID[32];
+	__shared__ float4 calc_coords[MAX_NUM_OF_ATOMS];
+    __shared__ unsigned long long int sAccumulator;
+	int run_id;    
+	int temp_covr_point;
+	float energy;
+    int bestID; 
+
+	// In this case this compute-unit is responsible for elitist selection
+	if ((blockIdx.x % cData.dockpars.pop_size) == 0) {
+        // Find and copy best member of population to position 0
+        if (threadIdx.x < cData.dockpars.pop_size)
+        {
+            bestID = blockIdx.x + threadIdx.x;
+            energy = pMem_energies_current[blockIdx.x + threadIdx.x];
+        }
+        else
+        {
+            bestID = -1;
+            energy = 1000000000000.0f;
+        }
+        
+        // Scan through population
+        for (int i = blockIdx.x + blockDim.x; i < blockIdx.x + cData.dockpars.pop_size; i += blockDim.x)
+        {
+            float e = pMem_energies_current[i];
+            if (e < energy)
+            {
+                bestID = i;
+                energy = e;
+            }
+        }
+        
+        // Reduce to shared memory by warp
+        int tgx = threadIdx.x & cData.warpmask;
+        WARPMINIMUM2(tgx, energy, bestID);
+        int warpID = threadIdx.x >> cData.warpbits;
+        if (tgx == 0)
+        {
+            sBestID[warpID] = bestID;
+            sBestEnergy[warpID] = energy;
+        }
+        __threadfence();
+        __syncthreads();
+               
+        // Perform final reduction in warp 0
+        if (warpID == 0)
+        {
+            int blocks = blockDim.x / 32;
+            if (tgx < blocks)
+            {
+                bestID = sBestID[tgx];
+                energy = sBestEnergy[tgx];
+            }
+            else
+            {
+                bestID = -1;
+                energy = 1000000000.0f;
+            }
+            WARPMINIMUM2(tgx, energy, bestID);     
+            
+            if (tgx == 0)
+            {
+                pMem_energies_next[blockIdx.x] = energy;
+                cData.pMem_evals_of_new_entities[blockIdx.x] = 0;
+                sBestID[0] = bestID;
+            }
+        }
+        __threadfence();
+        __syncthreads();
+        
+        // Copy best genome to next generation
+        int dOffset = blockIdx.x * GENOTYPE_LENGTH_IN_GLOBMEM;
+        int sOffset = (blockIdx.x + sBestID[0]) * GENOTYPE_LENGTH_IN_GLOBMEM;
+        for (int i = threadIdx.x ; i < cData.dockpars.num_of_genes; i += blockDim.x)
+        {
+            pMem_conformations_next[dOffset + i] = pMem_conformations_current[sOffset + i];
+        }
+	}
+	else
+	{
+		// Generating the following random numbers: 
+		// [0..3] for parent candidates,
+		// [4..5] for binary tournaments, [6] for deciding crossover,
+		// [7..8] for crossover points, [9] for local search
+		for (uint32_t gene_counter = threadIdx.x;
+		     gene_counter < 10;
+		     gene_counter += blockDim.x) {
+			 randnums[gene_counter] = gpu_randf(cData.pMem_prng_states);
+		}
+
+		// Determining run ID
+        run_id = blockIdx.x / cData.dockpars.pop_size;
+        __threadfence();
+        __syncthreads();
+
+
+		if (threadIdx.x < 4)	//it is not ensured that the four candidates will be different...
+		{
+			parent_candidates[threadIdx.x]  = (int) (cData.dockpars.pop_size*randnums[threadIdx.x]); //using randnums[0..3]
+			candidate_energies[threadIdx.x] = pMem_energies_current[run_id*cData.dockpars.pop_size+parent_candidates[threadIdx.x]];
+		}
+        __threadfence();
+        __syncthreads();
+
+		if (threadIdx.x < 2) 
+		{
+			// Notice: dockpars_tournament_rate was scaled down to [0,1] in host
+			// to reduce number of operations in device
+			if (candidate_energies[2*threadIdx.x] < candidate_energies[2*threadIdx.x+1])
+            {
+				if (/*100.0f**/randnums[4+threadIdx.x] < cData.dockpars.tournament_rate) {		//using randnum[4..5]
+					parents[threadIdx.x] = parent_candidates[2*threadIdx.x];
+				}
+				else {
+					parents[threadIdx.x] = parent_candidates[2*threadIdx.x+1];
+				}
+            }
+			else
+            {
+				if (/*100.0f**/randnums[4+threadIdx.x] < cData.dockpars.tournament_rate) {
+					parents[threadIdx.x] = parent_candidates[2*threadIdx.x+1];
+				}
+				else {
+					parents[threadIdx.x] = parent_candidates[2*threadIdx.x];
+				}
+            }
+		}
+        __threadfence();
+        __syncthreads();
+
+		// Performing crossover
+		// Notice: dockpars_crossover_rate was scaled down to [0,1] in host
+		// to reduce number of operations in device
+		if (/*100.0f**/randnums[6] < cData.dockpars.crossover_rate)	// Using randnums[6]
+		{
+			if (threadIdx.x < 2) {
+				// Using randnum[7..8]
+				covr_point[threadIdx.x] = (int) ((cData.dockpars.num_of_genes-1)*randnums[7+threadIdx.x]);
+			}
+            __threadfence();
+            __syncthreads();
+			
+			// covr_point[0] should store the lower crossover-point
+			if (threadIdx.x == 0) {
+				if (covr_point[1] < covr_point[0]) {
+					temp_covr_point = covr_point[1];
+					covr_point[1]   = covr_point[0];
+					covr_point[0]   = temp_covr_point;
+				}
+			}
+
+            __threadfence();
+            __syncthreads();
+
+			for (uint32_t gene_counter = threadIdx.x;
+			     gene_counter < cData.dockpars.num_of_genes;
+			     gene_counter+= blockDim.x)
+			{
+				// Two-point crossover
+				if (covr_point[0] != covr_point[1]) 
+				{
+					if ((gene_counter <= covr_point[0]) || (gene_counter > covr_point[1]))
+						offspring_genotype[gene_counter] = pMem_conformations_current[(run_id*cData.dockpars.pop_size+parents[0])*GENOTYPE_LENGTH_IN_GLOBMEM+gene_counter];
+					else
+						offspring_genotype[gene_counter] = pMem_conformations_current[(run_id*cData.dockpars.pop_size+parents[1])*GENOTYPE_LENGTH_IN_GLOBMEM+gene_counter];
+				}
+				// Single-point crossover
+				else
+				{									             
+					if (gene_counter <= covr_point[0])
+						offspring_genotype[gene_counter] = pMem_conformations_current[(run_id*cData.dockpars.pop_size+parents[0])*GENOTYPE_LENGTH_IN_GLOBMEM+gene_counter];
+					else
+						offspring_genotype[gene_counter] = pMem_conformations_current[(run_id*cData.dockpars.pop_size+parents[1])*GENOTYPE_LENGTH_IN_GLOBMEM+gene_counter];
+				}
+			}
+		}
+		else	//no crossover
+		{
+            for (uint32_t gene_counter = threadIdx.x;
+			     gene_counter < cData.dockpars.num_of_genes;
+			     gene_counter+= blockDim.x)
+            {
+                offspring_genotype[gene_counter] = pMem_conformations_current[(run_id*cData.dockpars.pop_size+parents[0])*GENOTYPE_LENGTH_IN_GLOBMEM + gene_counter];
+            }
+		} // End of crossover
+
+        __threadfence();
+        __syncthreads();
+
+		// Performing mutation
+		for (uint32_t gene_counter = threadIdx.x;
+		     gene_counter < cData.dockpars.num_of_genes;
+		     gene_counter+= blockDim.x)
+		{
+			// Notice: dockpars_mutation_rate was scaled down to [0,1] in host
+			// to reduce number of operations in device
+			if (/*100.0f**/gpu_randf(cData.pMem_prng_states) < cData.dockpars.mutation_rate)
+			{
+				// Translation genes
+				if (gene_counter < 3) {
+					offspring_genotype[gene_counter] += cData.dockpars.abs_max_dmov*(2*gpu_randf(cData.pMem_prng_states)-1);
+				}
+				// Orientation and torsion genes
+				else {
+					offspring_genotype[gene_counter] += cData.dockpars.abs_max_dang*(2*gpu_randf(cData.pMem_prng_states)-1);
+					map_angle(offspring_genotype[gene_counter]);
+				}
+
+			}
+		} // End of mutation
+
+		// Calculating energy of new offspring
+        __threadfence();
+        __syncthreads();
+        gpu_calc_energy(
+            offspring_genotype,
+			energy,
+			run_id,
+			calc_coords,
+            &sAccumulator
+		);
+        
+        
+        if (threadIdx.x == 0) {
+            pMem_energies_next[blockIdx.x] = energy;
+            cData.pMem_evals_of_new_entities[blockIdx.x] = 1;
+
+			#if defined (DEBUG_ENERGY_KERNEL4)
+			printf("%-18s [%-5s]---{%-5s}   [%-10.8f]---{%-10.8f}\n", "-ENERGY-KERNEL4-", "GRIDS", "INTRA", interE, intraE);
+			#endif
+        }
+
+
+		// Copying new offspring to next generation
+        for (uint32_t gene_counter = threadIdx.x;
+		     gene_counter < cData.dockpars.num_of_genes;
+		     gene_counter+= blockDim.x)
+        {
+            pMem_conformations_next[(run_id*cData.dockpars.pop_size+parents[0])*GENOTYPE_LENGTH_IN_GLOBMEM + gene_counter] = offspring_genotype[gene_counter];
+        }        
+    }
+}
+
+
+void gpu_gen_and_eval_newpops(
+    uint32_t blocks,
+    uint32_t threadsPerBlock,
+    float* pMem_conformations_current,
+    float* pMem_energies_current,
+    float* pMem_conformations_next,
+    float* pMem_energies_next
+)
+{
+    gpu_gen_and_eval_newpops_kernel<<<blocks, threadsPerBlock>>>(pMem_conformations_current, pMem_energies_current, pMem_conformations_next, pMem_energies_next);
+}

--- a/cuda/kernel4.cu
+++ b/cuda/kernel4.cu
@@ -51,7 +51,7 @@ gpu_gen_and_eval_newpops_kernel(
     __shared__ float sBestEnergy[32];
     __shared__ int sBestID[32];
 	__shared__ float4 calc_coords[MAX_NUM_OF_ATOMS];
-    __shared__ long long int sAccumulator;
+    __shared__ float sFloatAccumulator;
 	int run_id;    
 	int temp_covr_point;
 	float energy;
@@ -277,7 +277,7 @@ gpu_gen_and_eval_newpops_kernel(
 			energy,
 			run_id,
 			calc_coords,
-            &sAccumulator
+            &sFloatAccumulator
 		);
         
         
@@ -300,7 +300,7 @@ gpu_gen_and_eval_newpops_kernel(
         }        
     }
 #if 0
-    if ((threadIdx.x == 0) && (blockIdx.x == 151))
+    if ((threadIdx.x == 0) && (blockIdx.x == 0))
     {
         printf("%06d %16.8f ", blockIdx.x, pMem_energies_next[blockIdx.x]);
         for (int i = 0; i < cData.dockpars.num_of_genes; i++)

--- a/cuda/kernel_ad.cu
+++ b/cuda/kernel_ad.cu
@@ -81,7 +81,7 @@ gpu_gradient_minAD_kernel(
 	__shared__ float genotype[ACTUAL_GENOTYPE_LENGTH];
 
 	// Iteration counter for the minimizer
-	uint32_t iteration_cnt; 
+	uint32_t iteration_cnt = 0; 
 
 	if (threadIdx.x == 0)
 	{
@@ -96,9 +96,6 @@ gpu_gradient_minAD_kernel(
 		}
 		
 		energy = pMem_energies_next[run_id * cData.dockpars.pop_size + entity_id];
-
-		// Initializing gradient-minimizer counters and flags
-		iteration_cnt  = 0;
 
 		#if defined (DEBUG_ADADELTA_MINIMIZER) || defined (PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION)
 		printf("\n");
@@ -404,7 +401,7 @@ gpu_gradient_minAD_kernel(
 
 	// Updating eval counter and energy
 	if (threadIdx.x == 0) {
-		cData.dockpars.evals_of_new_entities[run_id * cData.dockpars.pop_size + entity_id] += iteration_cnt;
+		cData.pMem_evals_of_new_entities[run_id * cData.dockpars.pop_size + entity_id] += iteration_cnt;
 		pMem_energies_next[run_id * cData.dockpars.pop_size + entity_id] = best_energy;
 
 		#if defined (DEBUG_ADADELTA_MINIMIZER) || defined (PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION)

--- a/cuda/kernel_ad.cu
+++ b/cuda/kernel_ad.cu
@@ -1,0 +1,424 @@
+/*
+
+AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian Genetic Algorithm
+Copyright (C) 2017 TU Darmstadt, Embedded Systems and Applications Group, Germany. All rights reserved.
+For some of the code, Copyright (C) 2019 Computational Structural Biology Center, the Scripps Research Institute.
+
+AutoDock is a Trade Mark of the Scripps Research Institute.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+// #define AD_RHO_CRITERION
+
+// Gradient-based adadelta minimizer
+// https://arxiv.org/pdf/1212.5701.pdf
+// Alternative to Solis-Wets / Steepest-Descent / FIRE
+
+// "rho": controls degree of memory of previous gradients
+//        ranges between [0, 1[
+//        "rho" = 0.9 most popular value
+// "epsilon":  to better condition the square root
+
+// Adadelta parameters (TODO: to be moved to header file?)
+//#define RHO		0.9f
+//#define EPSILON 	1e-6
+#define RHO		0.8f
+#define EPSILON 	1e-2f
+
+// Enabling "DEBUG_ENERGY_ADADELTA" requires
+// manually enabling "DEBUG_ENERGY_KERNEL" in calcenergy.cl
+//#define DEBUG_ENERGY_ADADELTA
+	//#define PRINT_ADADELTA_ENERGIES
+	//#define PRINT_ADADELTA_GENES_AND_GRADS
+	//#define PRINT_ADADELTA_ATOMIC_COORDS
+	//#define DEBUG_SQDELTA_ADADELTA
+
+// Enable DEBUG_ADADELTA_MINIMIZER for a seeing a detailed ADADELTA evolution
+// If only PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION is enabled,
+// then a only a simplified ADADELTA evolution will be shown
+//#define DEBUG_ADADELTA_MINIMIZER
+	//#define PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION
+
+// Enable this for debugging ADADELTA from a defined initial genotype
+//#define DEBUG_ADADELTA_INITIAL_2BRT
+
+__global__ void
+__launch_bounds__(NUM_OF_THREADS_PER_BLOCK, 1024 / NUM_OF_THREADS_PER_BLOCK)
+gpu_gradient_minAD_kernel(	
+    float* pMem_conformations_next,
+	float* pMem_energies_next
+)
+//The GPU global function performs gradient-based minimization on (some) entities of conformations_next.
+//The number of OpenCL compute units (CU) which should be started equals to num_of_minEntities*num_of_runs.
+//This way the first num_of_lsentities entity of each population will be subjected to local search
+//(and each CU carries out the algorithm for one entity).
+//Since the first entity is always the best one in the current population,
+//it is always tested according to the ls probability, and if it not to be
+//subjected to local search, the entity with ID num_of_lsentities is selected instead of the first one (with ID 0).
+{
+	// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+
+	// Determining entity, and its run, energy, and genotype
+	int   run_id = blockIdx.x / cData.dockpars.num_of_lsentities;
+	int   entity_id = blockIdx.x - run_id * cData.dockpars.num_of_lsentities;
+	float energy;
+	__shared__ float genotype[ACTUAL_GENOTYPE_LENGTH];
+
+	// Iteration counter for the minimizer
+	uint iteration_cnt; 
+
+	if (threadIdx.x == 0)
+	{
+		// Since entity 0 is the best one due to elitism,
+		// it should be subjected to random selection
+		if (entity_id == 0) {
+			// If entity 0 is not selected according to LS-rate,
+			// choosing another entity
+			if (100.0f*gpu_randf(cData.dockpars.prng_states) > cData.dockpars.lsearch_rate) {
+				entity_id = cData.dockpars.num_of_lsentities; // AT - Should this be (uint)(dockpars_pop_size * gpu_randf(dockpars_prng_states))?
+			}
+		}
+		
+		energy = pMem_energies_next[run_id * cData.dockpars.pop_size + entity_id];
+
+		// Initializing gradient-minimizer counters and flags
+		iteration_cnt  = 0;
+
+		#if defined (DEBUG_ADADELTA_MINIMIZER) || defined (PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION)
+		printf("\n");
+		printf("-------> Start of ADADELTA minimization cycle\n");
+		printf("%20s %6u\n", "run_id: ", run_id);
+		printf("%20s %6u\n", "entity_id: ", entity_id);
+		printf("\n");
+		printf("%20s \n", "LGA genotype: ");
+		printf("%20s %.6f\n", "initial energy: ", energy);
+		#endif
+	}
+    
+
+    int offset = (run_id * cData.dockpars.pop_size + entity_id) * GENOTYPE_LENGTH_IN_GLOBMEM;
+    for (int i = threadIdx.x ; i < cData.dockpars.num_of_genes; i += blockDim.x)
+    {
+        genotype[i] = pMem_conformations_next[offset + i];
+    }
+
+	// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+         
+	// Partial results of the gradient step
+	__shared__ float gradient[ACTUAL_GENOTYPE_LENGTH];
+
+	// Energy may go up, so we keep track of the best energy ever calculated.
+	// Then, we return the genotype corresponding 
+	// to the best observed energy, i.e. "best_genotype"
+	__shared__ float best_energy;
+	__shared__ float best_genotype[ACTUAL_GENOTYPE_LENGTH];
+
+	// -------------------------------------------------------------------
+	// Calculate gradients (forces) for intermolecular energy
+	// Derived from autodockdev/maps.py
+	// -------------------------------------------------------------------
+	// Gradient of the intermolecular energy per each ligand atom
+	// Also used to store the accummulated gradient per each ligand atom
+	__shared__ float gradient_inter_x[MAX_NUM_OF_ATOMS];
+	__shared__ float gradient_inter_y[MAX_NUM_OF_ATOMS];
+	__shared__ float gradient_inter_z[MAX_NUM_OF_ATOMS];
+
+	// Gradient of the intramolecular energy per each ligand atom
+	__shared__ float gradient_intra_x[MAX_NUM_OF_ATOMS];
+	__shared__ float gradient_intra_y[MAX_NUM_OF_ATOMS];
+	__shared__ float gradient_intra_z[MAX_NUM_OF_ATOMS];
+
+	// Ligand-atom position and partial energies
+	__shared__ float4 calc_coords[MAX_NUM_OF_ATOMS];
+
+	#if defined (DEBUG_ENERGY_KERNEL)
+	float interE;
+	float intraE;
+	#endif
+
+	// Vector for storing squared gradients E[g^2]
+	__shared__ float square_gradient[ACTUAL_GENOTYPE_LENGTH];
+
+	// Update vector, i.e., "delta".
+	// It is added to the genotype to create the next genotype.
+	// E.g. in steepest descent "delta" is -1.0 * stepsize * gradient
+	__shared__ float delta[ACTUAL_GENOTYPE_LENGTH];
+
+	// Squared updates E[dx^2]
+	__shared__ float square_delta[ACTUAL_GENOTYPE_LENGTH];
+    
+    __shared__ unsigned long long int sAccumulator64;
+
+	// Asynchronous copy should be finished by here
+	__threadfence();
+    __syncthreads();
+
+	// Enable this for debugging ADADELTA from a defined initial genotype
+
+	// Initializing vectors
+	for(uint i = threadIdx.x; 
+		 i < cData.dockpars.num_of_genes; 
+		 i+= blockDim.x) {
+		gradient[i]        = 0.0f;
+		square_gradient[i] = 0.0f;
+		delta[i]           = 0.0f;
+		square_delta[i]    = 0.0f;
+		best_genotype[i] = genotype[i];
+	}
+
+	// Initializing best energy
+	if (threadIdx.x == 0) {
+		best_energy = INFINITY;
+	}
+
+#ifdef AD_RHO_CRITERION
+	__shared__ float rho;
+	__shared__ int cons_succ;
+	__shared__ int cons_fail;
+	if (threadIdx.x == 0) {
+		rho = 1.0f;
+		cons_succ = 0;
+		cons_fail = 0;
+	}
+#endif
+	// Perform adadelta iterations
+
+	// The termination criteria is based on 
+	// a maximum number of iterations, and
+	// the minimum step size allowed for single-floating point numbers 
+	// (IEEE-754 single float has a precision of about 6 decimal digits)
+	do {
+		// Printing number of ADADELTA iterations
+		#if defined (DEBUG_ADADELTA_MINIMIZER) || defined (PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION)
+		if (threadIdx.x == 0) {
+			#if defined (DEBUG_ADADELTA_MINIMIZER)
+			printf("%s\n", "----------------------------------------------------------");
+			#endif
+			printf("%-15s %-3u ", "# ADADELTA iteration: ", iteration_cnt);
+		}
+		#endif
+
+		// =============================================================
+		// =============================================================
+		// =============================================================
+		// Calculating energy & gradient
+		__syncthreads();
+        __threadfence();
+
+		gpu_calc_energrad(
+				// Some OpenCL compilers don't allow declaring 
+				// local variables within non-kernel functions.
+				// These local variables must be declared in a kernel, 
+				// and then passed to non-kernel functions.
+				genotype,
+				energy,
+				run_id,
+
+				calc_coords,
+				#if defined (DEBUG_ENERGY_KERNEL)
+				interE,
+				intraE,
+				#endif
+				// Gradient-related arguments
+				// Calculate gradients (forces) for intermolecular energy
+				// Derived from autodockdev/maps.py
+				gradient_inter_x,
+				gradient_inter_y,
+				gradient_inter_z,
+				gradient_intra_x,
+				gradient_intra_y,
+				gradient_intra_z,
+				gradient,
+                &sAccumulator64
+				);
+		// =============================================================
+		// =============================================================
+		// =============================================================
+		#if defined (DEBUG_ENERGY_ADADELTA)
+		if (threadIdx.x == 0) {
+			#if defined (PRINT_ADADELTA_ENERGIES)
+			printf("\n");
+			printf("%-10s %-10.6f \n", "intra: ",  intraE);
+			printf("%-10s %-10.6f \n", "grids: ",  interE);
+			printf("%-10s %-10.6f \n", "Energy: ", intraE + interE));
+			#endif
+
+			#if defined (PRINT_ADADELTA_GENES_AND_GRADS)
+			for(uint i = 0; i < cData.dockpars.num_of_genes; i++) {
+				if (i == 0) {
+					printf("\n%s\n", "----------------------------------------------------------");
+					printf("%13s %13s %5s %15s %15s\n", "gene_id", "gene.value", "|", "gene.grad", "(autodockdevpy units)");
+				}
+				printf("%13u %13.6f %5s %15.6f %15.6f\n", i, genotype[i], "|", gradient[i], (i<3)? (gradient[i]/0.375f):(gradient[i]*180.0f/PI_FLOAT));
+			}
+			#endif
+
+			#if defined (PRINT_ADADELTA_ATOMIC_COORDS)
+			for(uint i = 0; i < cData.dockpars.num_of_atoms; i++) {
+				if (i == 0) {
+					printf("\n%s\n", "----------------------------------------------------------");
+					printf("%s\n", "Coordinates calculated by calcenergy.cl");
+					printf("%12s %12s %12s %12s\n", "atom_id", "coords.x", "coords.y", "coords.z");
+				}
+				printf("%12u %12.6f %12.6f %12.6f\n", i, calc_coords_x[i], calc_coords_y[i], calc_coords_z[i]);
+			}
+			printf("\n");
+			#endif
+		}
+		__threadfence();
+        __syncthreads();
+		#endif // DEBUG_ENERGY_ADADELTA
+
+		for(int i = threadIdx.x;
+			 i < cData.dockpars.num_of_genes;
+			 i+= blockDim.x) {
+
+			if (energy < best_energy) // we need to be careful not to change best_energy until we had a chance to update the whole array
+				best_genotype[i] = genotype[i];
+
+			// Accummulating gradient^2 (eq.8 in the paper)
+			// square_gradient corresponds to E[g^2]
+			square_gradient[i] = RHO * square_gradient[i] + (1.0f - RHO) * gradient[i] * gradient[i];
+
+			// Computing update (eq.9 in the paper)
+			delta[i] = -1.0f * gradient[i] * sqrt((float)(square_delta[i] + EPSILON) / (float)(square_gradient[i] + EPSILON));
+
+			// Accummulating update^2
+			// square_delta corresponds to E[dx^2]
+			square_delta[i] = RHO * square_delta[i] + (1.0f - RHO) * delta[i] * delta [i];
+
+			// Applying update
+			genotype[i] += delta[i];
+		}
+		__threadfence();
+        __syncthreads();
+
+		#if defined (DEBUG_SQDELTA_ADADELTA)
+		if (/*(get_group_id(0) == 0) &&*/ (threadIdx.x == 0)) {
+			for(int i = 0; i < cData.dockpars.num_of_genes; i++) {
+				if (i == 0) {
+					printf("\n%s\n", "----------------------------------------------------------");
+					printf("%13s %20s %15s %15s %15s\n", "gene", "sq_grad", "delta", "sq_delta", "new.genotype");
+				}
+				printf("%13u %20.6f %15.6f %15.6f %15.6f\n", i, square_gradient[i], delta[i], square_delta[i], genotype[i]);
+			}
+		}
+		__threadfence();
+        __syncthreads();
+		#endif
+
+		// Updating number of ADADELTA iterations (energy evaluations)
+		if (threadIdx.x == 0) {
+			if (energy < best_energy)
+			{
+				best_energy = energy;
+#ifdef AD_RHO_CRITERION
+				cons_succ++;
+				cons_fail = 0;
+#endif
+			}
+#ifdef AD_RHO_CRITERION
+			else
+			{
+				cons_succ = 0;
+				cons_fail++;
+			}
+#endif
+
+			iteration_cnt = iteration_cnt + 1;
+
+			#if defined (DEBUG_ADADELTA_MINIMIZER) || defined (PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION)
+			printf("%20s %10.6f\n", "new.energy: ", energy);
+			#endif
+
+			#if defined (DEBUG_ENERGY_ADADELTA)
+			printf("%-18s [%-5s]---{%-5s}   [%-10.7f]---{%-10.7f}\n", "-ENERGY-KERNEL7-", "GRIDS", "INTRA", partial_interE[0], partial_intraE[0]);
+			#endif
+#ifdef AD_RHO_CRITERION
+			if (cons_succ >= 4)
+			{
+				rho *= LS_EXP_FACTOR;
+				cons_succ = 0;
+			}
+			else
+				if (cons_fail >= 4)
+				{
+					rho *= LS_CONT_FACTOR;
+					cons_fail = 0;
+				}
+#endif
+		}
+		__threadfence();
+        __syncthreads(); // making sure that iteration_cnt is up-to-date
+#ifdef AD_RHO_CRITERION
+	} while ((iteration_cnt < cData.dockpars.max_num_of_iters)  && (rho > 0.01f));
+#else
+	} while (iteration_cnt < cData.dockpars.max_num_of_iters);
+#endif
+	// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+
+	// Mapping torsion angles
+	for (uint32_t gene_counter = threadIdx.x+3;
+	          gene_counter < cData.dockpars.num_of_genes;
+	          gene_counter += blockDim.x) {
+		map_angle(best_genotype[gene_counter]);
+	}
+    
+    
+
+	// Updating old offspring in population
+	__threadfence();
+    __syncthreads();
+    
+    offset = (run_id * cData.dockpars.pop_size + entity_id) * GENOTYPE_LENGTH_IN_GLOBMEM;
+	for (uint gene_counter = threadIdx.x;
+	          gene_counter < cData.dockpars.num_of_genes;
+	          gene_counter+= blockDim.x)
+    {
+        pMem_conformations_next[gene_counter + offset] = best_genotype[gene_counter];
+    }
+
+
+	// Updating eval counter and energy
+	if (threadIdx.x == 0) {
+		cData.dockpars.evals_of_new_entities[run_id * cData.dockpars.pop_size + entity_id] += iteration_cnt;
+		pMem_energies_next[run_id * cData.dockpars.pop_size + entity_id] = best_energy;
+
+		#if defined (DEBUG_ADADELTA_MINIMIZER) || defined (PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION)
+		printf("\n");
+		printf("Termination criteria: ( #adadelta-iters >= %-3u )\n", dockpars_max_num_of_iters);
+		printf("-------> End of ADADELTA minimization cycle, num of energy evals: %u, final energy: %.6f\n", iteration_cnt, best_energy);
+		#endif
+	}
+}
+
+
+void gpu_gradient_minAD(
+    uint32_t blocks,
+    uint32_t threads,
+    float* pMem_conformations_next,
+	float* pMem_energies_next
+)
+{
+    gpu_gradient_minAD_kernel<<<blocks, threads>>>(pMem_conformations_next, pMem_energies_next);
+}

--- a/cuda/kernel_ad.cu
+++ b/cuda/kernel_ad.cu
@@ -90,7 +90,7 @@ gpu_gradient_minAD_kernel(
 		if (entity_id == 0) {
 			// If entity 0 is not selected according to LS-rate,
 			// choosing another entity
-			if (100.0f*gpu_randf(cData.dockpars.prng_states) > cData.dockpars.lsearch_rate) {
+			if (100.0f*gpu_randf(cData.pMem_prng_states) > cData.dockpars.lsearch_rate) {
 				entity_id = cData.dockpars.num_of_lsentities; // AT - Should this be (uint)(dockpars_pop_size * gpu_randf(dockpars_prng_states))?
 			}
 		}
@@ -422,4 +422,12 @@ void gpu_gradient_minAD(
 {
     gpu_gradient_minAD_kernel<<<blocks, threads>>>(pMem_conformations_next, pMem_energies_next);
     LAUNCHERROR("gpu_gradient_minAD_kernel");     
+#if 0  
+    cudaError_t status;
+    status = cudaDeviceSynchronize();
+    RTERROR(status, "gpu_gradient_minAD_kernel");
+    status = cudaDeviceReset();
+    RTERROR(status, "failed to shut down");
+    exit(0);
+#endif
 }

--- a/cuda/kernel_ad.cu
+++ b/cuda/kernel_ad.cu
@@ -171,7 +171,7 @@ gpu_gradient_minAD_kernel(
 	// Enable this for debugging ADADELTA from a defined initial genotype
 
 	// Initializing vectors
-	for(uint i = threadIdx.x; 
+	for(uint32_t i = threadIdx.x; 
 		 i < cData.dockpars.num_of_genes; 
 		 i+= blockDim.x) {
 		gradient[i]        = 0.0f;
@@ -246,6 +246,7 @@ gpu_gradient_minAD_kernel(
 				gradient,
                 &sAccumulator64
 				);
+
 		// =============================================================
 		// =============================================================
 		// =============================================================

--- a/cuda/kernel_ad.cu
+++ b/cuda/kernel_ad.cu
@@ -81,7 +81,7 @@ gpu_gradient_minAD_kernel(
 	__shared__ float genotype[ACTUAL_GENOTYPE_LENGTH];
 
 	// Iteration counter for the minimizer
-	uint iteration_cnt; 
+	uint32_t iteration_cnt; 
 
 	if (threadIdx.x == 0)
 	{
@@ -326,6 +326,7 @@ gpu_gradient_minAD_kernel(
 		#endif
 
 		// Updating number of ADADELTA iterations (energy evaluations)
+        iteration_cnt = iteration_cnt + 1;
 		if (threadIdx.x == 0) {
 			if (energy < best_energy)
 			{
@@ -343,7 +344,7 @@ gpu_gradient_minAD_kernel(
 			}
 #endif
 
-			iteration_cnt = iteration_cnt + 1;
+
 
 			#if defined (DEBUG_ADADELTA_MINIMIZER) || defined (PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION)
 			printf("%20s %10.6f\n", "new.energy: ", energy);
@@ -359,11 +360,13 @@ gpu_gradient_minAD_kernel(
 				cons_succ = 0;
 			}
 			else
+            {
 				if (cons_fail >= 4)
 				{
 					rho *= LS_CONT_FACTOR;
 					cons_fail = 0;
 				}
+            }
 #endif
 		}
 		__threadfence();

--- a/cuda/kernel_ad.cu
+++ b/cuda/kernel_ad.cu
@@ -421,4 +421,5 @@ void gpu_gradient_minAD(
 )
 {
     gpu_gradient_minAD_kernel<<<blocks, threads>>>(pMem_conformations_next, pMem_energies_next);
+    LAUNCHERROR("gpu_gradient_minAD_kernel");     
 }

--- a/cuda/kernel_ad.cu
+++ b/cuda/kernel_ad.cu
@@ -90,16 +90,11 @@ gpu_gradient_minAD_kernel(
     
 	// Gradient of the intermolecular energy per each ligand atom
 	// Also used to store the accummulated gradient per each ligand atom
-	float3* gradient_inter = calc_coords + cData.dockpars.num_of_atoms;
+	float3* cartesian_gradient = calc_coords + cData.dockpars.num_of_atoms;
 
-	// Gradient of the intramolecular energy per each ligand atom
-	float3* gradient_intra = gradient_inter + cData.dockpars.num_of_atoms;
-
-
-  
 
     // Genotype pointers
-	float* genotype = (float*)(gradient_intra + cData.dockpars.num_of_atoms);
+	float* genotype = (float*)(cartesian_gradient + cData.dockpars.num_of_atoms);
 	float* best_genotype = genotype + cData.dockpars.num_of_genes;  
 
 
@@ -250,8 +245,7 @@ gpu_gradient_minAD_kernel(
 				// Gradient-related arguments
 				// Calculate gradients (forces) for intermolecular energy
 				// Derived from autodockdev/maps.py
-				gradient_inter,
-				gradient_intra,
+				cartesian_gradient,
 				gradient,
                 &sFloatAccumulator
 				);
@@ -444,7 +438,7 @@ void gpu_gradient_minAD(
 	float* pMem_energies_next
 )
 {
-    size_t sz_shared = (9 * cpuData.dockpars.num_of_atoms + 5 * cpuData.dockpars.num_of_genes) * sizeof(float);
+    size_t sz_shared = (6 * cpuData.dockpars.num_of_atoms + 5 * cpuData.dockpars.num_of_genes) * sizeof(float);
     gpu_gradient_minAD_kernel<<<blocks, threads, sz_shared>>>(pMem_conformations_next, pMem_energies_next);
     LAUNCHERROR("gpu_gradient_minAD_kernel");     
 #if 0

--- a/cuda/kernel_ad.cu
+++ b/cuda/kernel_ad.cu
@@ -217,8 +217,8 @@ gpu_gradient_minAD_kernel(
 		// =============================================================
 		// =============================================================
 		// Calculating energy & gradient
-		__syncthreads();
         __threadfence();
+		__syncthreads();
 
 		gpu_calc_energrad(
 				// Some OpenCL compilers don't allow declaring 

--- a/cuda/kernel_adam.cu
+++ b/cuda/kernel_adam.cu
@@ -1,0 +1,442 @@
+/*
+
+AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian Genetic Algorithm
+Copyright (C) 2017 TU Darmstadt, Embedded Systems and Applications Group, Germany. All rights reserved.
+For some of the code, Copyright (C) 2019 Computational Structural Biology Center, the Scripps Research Institute.
+
+AutoDock is a Trade Mark of the Scripps Research Institute.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+// #define AD_RHO_CRITERION
+
+// Gradient-based adadelta minimizer
+// https://arxiv.org/pdf/1212.5701.pdf
+// Alternative to Solis-Wets / Steepest-Descent / FIRE
+
+// "rho": controls degree of memory of previous gradients
+//        ranges between [0, 1[
+//        "rho" = 0.9 most popular value
+// "epsilon":  to better condition the square root
+
+// Adadelta parameters (TODO: to be moved to header file?)
+//#define RHO		0.9f
+//#define EPSILON 	1e-6
+#define RHO		0.8f
+#define EPSILON 	1e-2f
+
+
+// Enable DEBUG_ADADELTA_MINIMIZER for a seeing a detailed ADADELTA evolution
+// If only PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION is enabled,
+// then a only a simplified ADADELTA evolution will be shown
+//#define DEBUG_ADADELTA_MINIMIZER
+	//#define PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION
+
+// Enable this for debugging ADADELTA from a defined initial genotype
+//#define DEBUG_ADADELTA_INITIAL_2BRT
+
+__global__ void
+__launch_bounds__(NUM_OF_THREADS_PER_BLOCK, 1024 / NUM_OF_THREADS_PER_BLOCK)
+gpu_gradient_minAdam_kernel(	
+    float* pMem_conformations_next,
+	float* pMem_energies_next
+)
+//The GPU global function performs gradient-based minimization on (some) entities of conformations_next.
+//The number of OpenCL compute units (CU) which should be started equals to num_of_minEntities*num_of_runs.
+//This way the first num_of_lsentities entity of each population will be subjected to local search
+//(and each CU carries out the algorithm for one entity).
+//Since the first entity is always the best one in the current population,
+//it is always tested according to the ls probability, and if it not to be
+//subjected to local search, the entity with ID num_of_lsentities is selected instead of the first one (with ID 0).
+{
+	// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+
+	// Determining entity, and its run, energy, and genotype
+	int   run_id = blockIdx.x / cData.dockpars.num_of_lsentities;
+	int   entity_id = blockIdx.x - run_id * cData.dockpars.num_of_lsentities;
+	float energy;  
+	// Energy may go up, so we keep track of the best energy ever calculated.
+	// Then, we return the genotype corresponding 
+	// to the best observed energy, i.e. "best_genotype"
+	__shared__ float best_energy;
+    __shared__ float sFloatAccumulator;
+    extern __shared__ float sFloatBuff[];
+
+	// Ligand-atom position and partial energies
+	float3* calc_coords = (float3*)sFloatBuff;  
+    
+	// Gradient of the intermolecular energy per each ligand atom
+	// Also used to store the accummulated gradient per each ligand atom
+	float3* cartesian_gradient = calc_coords + cData.dockpars.num_of_atoms;
+
+
+    // Genotype pointers
+	float* genotype = (float*)(cartesian_gradient + cData.dockpars.num_of_atoms);
+	float* best_genotype = genotype + cData.dockpars.num_of_genes;  
+
+
+	// Partial results of the gradient step
+	float* gradient = best_genotype + cData.dockpars.num_of_genes;
+
+	// Adam mt parameter
+	float* mt = gradient + cData.dockpars.num_of_genes;
+
+	// Adam vt parameter
+	float* vt = mt + cData.dockpars.num_of_genes;    
+
+
+    
+
+	// Iteration counter for the minimizer
+	uint32_t iteration_cnt = 0; 
+
+	if (threadIdx.x == 0)
+	{
+		// Since entity 0 is the best one due to elitism,
+		// it should be subjected to random selection
+		if (entity_id == 0) {
+			// If entity 0 is not selected according to LS-rate,
+			// choosing another entity
+			if (100.0f*gpu_randf(cData.pMem_prng_states) > cData.dockpars.lsearch_rate) {
+				entity_id = cData.dockpars.num_of_lsentities; // AT - Should this be (uint)(dockpars_pop_size * gpu_randf(dockpars_prng_states))?
+			}
+		}
+		
+		energy = pMem_energies_next[run_id * cData.dockpars.pop_size + entity_id];
+
+		#if defined (DEBUG_ADADELTA_MINIMIZER) || defined (PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION)
+		printf("\n");
+		printf("-------> Start of ADADELTA minimization cycle\n");
+		printf("%20s %6u\n", "run_id: ", run_id);
+		printf("%20s %6u\n", "entity_id: ", entity_id);
+		printf("\n");
+		printf("%20s \n", "LGA genotype: ");
+		printf("%20s %.6f\n", "initial energy: ", energy);
+		#endif
+	}
+    
+
+    int offset = (run_id * cData.dockpars.pop_size + entity_id) * GENOTYPE_LENGTH_IN_GLOBMEM;
+    for (int i = threadIdx.x ; i < cData.dockpars.num_of_genes; i += blockDim.x)
+    {
+        genotype[i] = pMem_conformations_next[offset + i];
+    }
+
+	// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+         
+
+
+
+
+
+	// -------------------------------------------------------------------
+	// Calculate gradients (forces) for intermolecular energy
+	// Derived from autodockdev/maps.py
+	// -------------------------------------------------------------------
+
+
+	#if defined (DEBUG_ENERGY_KERNEL)
+	float interE;
+	float intraE;
+	#endif
+
+
+
+	// Update vector, i.e., "delta".
+	// It is added to the genotype to create the next genotype.
+	// E.g. in steepest descent "delta" is -1.0 * stepsize * gradient
+
+
+	// Asynchronous copy should be finished by here
+	__threadfence();
+    __syncthreads();
+
+	// Enable this for debugging ADADELTA from a defined initial genotype
+
+	// Initializing vectors
+	for(uint32_t i = threadIdx.x; 
+		 i < cData.dockpars.num_of_genes; 
+		 i+= blockDim.x) {
+		gradient[i]        = 0.0f;
+		mt[i]              = 0.0f;
+		vt[i]              = 0.0f;
+		best_genotype[i] = genotype[i];
+	}
+
+	// Initializing best energy
+	if (threadIdx.x == 0) {
+		best_energy = INFINITY;
+	}
+
+#ifdef AD_RHO_CRITERION
+	__shared__ float rho;
+	__shared__ int cons_succ;
+	__shared__ int cons_fail;
+	if (threadIdx.x == 0) {
+		rho = 1.0f;
+		cons_succ = 0;
+		cons_fail = 0;
+	}
+#endif
+
+	// Perform adadelta iterations
+
+	// The termination criteria is based on 
+	// a maximum number of iterations, and
+	// the minimum step size allowed for single-floating point numbers 
+	// (IEEE-754 single float has a precision of about 6 decimal digits)
+	do {
+		// Printing number of ADADELTA iterations
+		#if defined (DEBUG_ADADELTA_MINIMIZER) || defined (PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION)
+		if (threadIdx.x == 0) {
+			#if defined (DEBUG_ADADELTA_MINIMIZER)
+			printf("%s\n", "----------------------------------------------------------");
+			#endif
+			printf("%-15s %-3u ", "# ADADELTA iteration: ", iteration_cnt);
+		}
+		#endif
+
+		// =============================================================
+		// =============================================================
+		// =============================================================
+		// Calculating energy & gradient
+        __threadfence();
+		__syncthreads();
+
+		gpu_calc_energrad(
+				// Some OpenCL compilers don't allow declaring 
+				// local variables within non-kernel functions.
+				// These local variables must be declared in a kernel, 
+				// and then passed to non-kernel functions.
+				genotype,
+				energy,
+				run_id,
+
+				calc_coords,
+				#if defined (DEBUG_ENERGY_KERNEL)
+				interE,
+				intraE,
+				#endif
+				// Gradient-related arguments
+				// Calculate gradients (forces) for intermolecular energy
+				// Derived from autodockdev/maps.py
+				cartesian_gradient,
+				gradient,
+                &sFloatAccumulator
+				);
+
+		// =============================================================
+		// =============================================================
+		// =============================================================
+		#if defined (DEBUG_ENERGY_ADADELTA)
+		if (threadIdx.x == 0) {
+			#if defined (PRINT_ADADELTA_ENERGIES)
+			printf("\n");
+			printf("%-10s %-10.6f \n", "intra: ",  intraE);
+			printf("%-10s %-10.6f \n", "grids: ",  interE);
+			printf("%-10s %-10.6f \n", "Energy: ", intraE + interE));
+			#endif
+
+			#if defined (PRINT_ADADELTA_GENES_AND_GRADS)
+			for(uint i = 0; i < cData.dockpars.num_of_genes; i++) {
+				if (i == 0) {
+					printf("\n%s\n", "----------------------------------------------------------");
+					printf("%13s %13s %5s %15s %15s\n", "gene_id", "gene.value", "|", "gene.grad", "(autodockdevpy units)");
+				}
+				printf("%13u %13.6f %5s %15.6f %15.6f\n", i, genotype[i], "|", gradient[i], (i<3)? (gradient[i]/0.375f):(gradient[i]*180.0f/PI_FLOAT));
+			}
+			#endif
+
+			#if defined (PRINT_ADADELTA_ATOMIC_COORDS)
+			for(uint i = 0; i < cData.dockpars.num_of_atoms; i++) {
+				if (i == 0) {
+					printf("\n%s\n", "----------------------------------------------------------");
+					printf("%s\n", "Coordinates calculated by calcenergy.cl");
+					printf("%12s %12s %12s %12s\n", "atom_id", "coords.x", "coords.y", "coords.z");
+				}
+				printf("%12u %12.6f %12.6f %12.6f\n", i, calc_coords_x[i], calc_coords_y[i], calc_coords_z[i]);
+			}
+			printf("\n");
+			#endif
+		}
+		__threadfence();
+        __syncthreads();
+		#endif // DEBUG_ENERGY_ADADELTA
+
+#if 0
+        if ((blockIdx.x == 0) && (threadIdx.x == 0))
+        {
+            printf("\n%d %16.8f\n", blockIdx.x);
+            float sum = 0.0;
+            for (uint32_t i = 0;
+            i < cData.dockpars.num_of_genes;
+            i++) {
+                //printf("%06d | %12.6f\n", i, gradient[i]);
+                //printf("%06d | %12.6f %12.6f %12.6f | %12.6f %12.6f %12.6f\n", i, gradient_inter_x[i], gradient_inter_y[i], gradient_inter_z[i], gradient_intra_x[i], gradient_intra_y[i], gradient_intra_z[i]);
+            }
+        }
+#endif
+        float beta1p = 1.0f - pow(cData.dockpars.adam_beta1, 1.0f + iteration_cnt);
+        float beta2p = 1.0f - pow(cData.dockpars.adam_beta2, 1.0f + iteration_cnt);
+
+		for(int i = threadIdx.x;
+			 i < cData.dockpars.num_of_genes;
+			 i+= blockDim.x) {
+
+			if (energy < best_energy) // we need to be careful not to change best_energy until we had a chance to update the whole array
+				best_genotype[i] = genotype[i];
+                
+            // Update Adam parameters
+            mt[i] = cData.dockpars.adam_beta1 * mt[i] + (1.0f - cData.dockpars.adam_beta1) * gradient[i];
+            vt[i] = cData.dockpars.adam_beta2 * vt[i] + (1.0f - cData.dockpars.adam_beta2) * gradient[i] * gradient[i];
+            float mp = mt[i] / beta1p;
+            float vp = vt[i] / beta2p;
+
+			// Applying update
+			genotype[i] -= mp / (sqrt(vp) + cData.dockpars.adam_epsilon);
+		}
+		__threadfence();
+        __syncthreads();
+
+		#if defined (DEBUG_SQDELTA_ADADELTA)
+		if (/*(get_group_id(0) == 0) &&*/ (threadIdx.x == 0)) {
+			for(int i = 0; i < cData.dockpars.num_of_genes; i++) {
+				if (i == 0) {
+					printf("\n%s\n", "----------------------------------------------------------");
+					printf("%13s %20s %15s %15s %15s\n", "gene", "sq_grad", "delta", "sq_delta", "new.genotype");
+				}
+				printf("%13u %20.6f %15.6f %15.6f %15.6f\n", i, square_gradient[i], delta[i], square_delta[i], genotype[i]);
+			}
+		}
+		__threadfence();
+        __syncthreads();
+		#endif
+
+		// Updating number of ADADELTA iterations (energy evaluations)
+        iteration_cnt = iteration_cnt + 1;
+		if (threadIdx.x == 0) {
+			if (energy < best_energy)
+			{
+				best_energy = energy;
+#ifdef AD_RHO_CRITERION
+				cons_succ++;
+				cons_fail = 0;
+#endif
+			}
+#ifdef AD_RHO_CRITERION
+			else
+			{
+				cons_succ = 0;
+				cons_fail++;
+			}
+#endif
+
+
+
+			#if defined (DEBUG_ADADELTA_MINIMIZER) || defined (PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION)
+			printf("%20s %10.6f\n", "new.energy: ", energy);
+			#endif
+
+			#if defined (DEBUG_ENERGY_ADADELTA)
+			printf("%-18s [%-5s]---{%-5s}   [%-10.7f]---{%-10.7f}\n", "-ENERGY-KERNEL7-", "GRIDS", "INTRA", partial_interE[0], partial_intraE[0]);
+			#endif
+#ifdef AD_RHO_CRITERION
+			if (cons_succ >= 4)
+			{
+				rho *= LS_EXP_FACTOR;
+				cons_succ = 0;
+			}
+			else
+            {
+				if (cons_fail >= 4)
+				{
+					rho *= LS_CONT_FACTOR;
+					cons_fail = 0;
+				}
+            }
+#endif
+		}
+		__threadfence();
+        __syncthreads(); // making sure that iteration_cnt is up-to-date
+#ifdef AD_RHO_CRITERION
+	} while ((iteration_cnt < cData.dockpars.max_num_of_iters)  && (rho > 0.01f));
+#else
+	} while (iteration_cnt < cData.dockpars.max_num_of_iters);
+#endif
+	// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------
+
+	// Mapping torsion angles
+	for (uint32_t gene_counter = threadIdx.x+3;
+	          gene_counter < cData.dockpars.num_of_genes;
+	          gene_counter += blockDim.x) {
+		map_angle(best_genotype[gene_counter]);
+	}
+    
+    
+
+	// Updating old offspring in population
+	__threadfence();
+    __syncthreads();
+    
+    offset = (run_id * cData.dockpars.pop_size + entity_id) * GENOTYPE_LENGTH_IN_GLOBMEM;
+	for (uint gene_counter = threadIdx.x;
+	          gene_counter < cData.dockpars.num_of_genes;
+	          gene_counter+= blockDim.x)
+    {
+        pMem_conformations_next[gene_counter + offset] = best_genotype[gene_counter];
+    }
+
+
+	// Updating eval counter and energy
+	if (threadIdx.x == 0) {
+		cData.pMem_evals_of_new_entities[run_id * cData.dockpars.pop_size + entity_id] += iteration_cnt;
+		pMem_energies_next[run_id * cData.dockpars.pop_size + entity_id] = best_energy;
+
+		#if defined (DEBUG_ADADELTA_MINIMIZER) || defined (PRINT_ADADELTA_MINIMIZER_ENERGY_EVOLUTION)
+		printf("\n");
+		printf("Termination criteria: ( #adadelta-iters >= %-3u )\n", dockpars_max_num_of_iters);
+		printf("-------> End of ADADELTA minimization cycle, num of energy evals: %u, final energy: %.6f\n", iteration_cnt, best_energy);
+		#endif
+	}
+}
+
+
+void gpu_gradient_minAdam(
+    uint32_t blocks,
+    uint32_t threads,
+    float* pMem_conformations_next,
+	float* pMem_energies_next
+)
+{
+    size_t sz_shared = (6 * cpuData.dockpars.num_of_atoms + 5 * cpuData.dockpars.num_of_genes) * sizeof(float);
+    gpu_gradient_minAdam_kernel<<<blocks, threads, sz_shared>>>(pMem_conformations_next, pMem_energies_next);
+    LAUNCHERROR("gpu_gradient_minAdam_kernel");     
+#if 0
+    cudaError_t status;
+    status = cudaDeviceSynchronize();
+    RTERROR(status, "gpu_gradient_minAdam_kernel");
+    status = cudaDeviceReset();
+    RTERROR(status, "failed to shut down");
+    exit(0);
+#endif
+}

--- a/cuda/kernels.cu
+++ b/cuda/kernels.cu
@@ -66,11 +66,6 @@ __device__ inline int64_t ullitolli(uint64_t u)
 
 #define ATOMICADDF32(pAccumulator, value) atomicAdd(pAccumulator, (value))
 #define ATOMICSUBF32(pAccumulator, value) atomicAdd(pAccumulator, -(value))
-
-
-#define RSCALE  (1ll << 30)
-static const float REDUCESCALEF             = (float)RSCALE;
-static const float ONEOVEREDUCESCALEF       = (float)1.0 / REDUCESCALEF;
 #define REDUCEFLOATSUM(value, pAccumulator) \
     if (threadIdx.x == 0) \
     { \
@@ -88,12 +83,12 @@ static const float ONEOVEREDUCESCALEF       = (float)1.0 / REDUCESCALEF;
         value                  += __shfl_sync(0xffffffff, value, tgx ^ 16); \
         if (tgx == 0) \
         { \
-            atomicAdd((unsigned long long int*)pAccumulator, llitoulli(llrintf(REDUCESCALEF * value))); \
+            atomicAdd(pAccumulator, value); \
         } \
     } \
     __threadfence(); \
     __syncthreads(); \
-    value = (float)(*pAccumulator) * ONEOVEREDUCESCALEF; \
+    value = (float)(*pAccumulator); \
     __syncthreads();
 
 

--- a/cuda/kernels.cu
+++ b/cuda/kernels.cu
@@ -95,12 +95,14 @@ __device__ inline int64_t ullitolli(uint64_t u)
 
 
 static __constant__ GpuData cData;
+static GpuData cpuData;
 
 void SetKernelsGpuData(GpuData* pData)
 {
     cudaError_t status;
     status = cudaMemcpyToSymbol(cData, pData, sizeof(GpuData));
     RTERROR(status, "SetKernelsGpuData copy to cData failed");
+    memcpy(&cpuData, pData, sizeof(GpuData));
 }
 
 void GetKernelsGpuData(GpuData* pData)

--- a/cuda/kernels.cu
+++ b/cuda/kernels.cu
@@ -122,3 +122,4 @@ void GetKernelsGpuData(GpuData* pData)
 #include "kernel3.cu"
 #include "kernel4.cu"
 #include "kernel_ad.cu"
+#include "kernel_adam.cu"

--- a/cuda/kernels.cu
+++ b/cuda/kernels.cu
@@ -88,7 +88,7 @@ static const float ONEOVEREDUCESCALEF       = (float)1.0 / REDUCESCALEF;
         value                  += __shfl_sync(0xffffffff, value, tgx ^ 16); \
         if (tgx == 0) \
         { \
-            atomicAdd(pAccumulator, llitoulli(llrintf(REDUCESCALEF * value))); \
+            atomicAdd((unsigned long long int*)pAccumulator, llitoulli(llrintf(REDUCESCALEF * value))); \
         } \
     } \
     __threadfence(); \

--- a/cuda/kernels.cu
+++ b/cuda/kernels.cu
@@ -24,9 +24,9 @@ __device__ inline int64_t ullitolli(uint64_t u)
         float v1    = v0; \
         int k1      = k0; \
         int otgx    = tgx ^ mask; \
-        float v2    = __shfl_sync(0xffffffff, k0, otgx); \
+        float v2    = __shfl_sync(0xffffffff, v0, otgx); \
         int k2      = __shfl_sync(0xffffffff, k0, otgx); \
-        int flag    = ((k1 > k2) ^ (tgx > otgx)) && (k1 != k2); \
+        int flag    = ((v1 < v2) ^ (tgx > otgx)) && (v1 != v2); \
         k0          = flag ? k1 : k2; \
         v0          = flag ? v1 : v2; \
     }

--- a/cuda/kernels.cu
+++ b/cuda/kernels.cu
@@ -1,0 +1,126 @@
+#include <cstdint>
+#include <cassert>
+#include "defines.h"
+#include "calcenergy.h"
+#include "GpuData.h"
+
+__device__ inline uint64_t llitoulli(int64_t l)
+{
+    uint64_t u;
+    asm("mov.b64    %0, %1;" : "=l"(u) : "l"(l));
+    return u;
+}
+
+__device__ inline int64_t ullitolli(uint64_t u)
+{
+    int64_t l;
+    asm("mov.b64    %0, %1;" : "=l"(l) : "l"(u));
+    return l;
+}
+
+
+#define WARPMINIMUMEXCHANGE(tgx, v0, k0, mask) \
+    { \
+        float v1    = v0; \
+        int k1      = k0; \
+        int otgx    = tgx ^ mask; \
+        float v2    = __shfl_sync(0xffffffff, k0, otgx); \
+        int k2      = __shfl_sync(0xffffffff, k0, otgx); \
+        int flag    = ((k1 > k2) ^ (tgx > otgx)) && (k1 != k2); \
+        k0          = flag ? k1 : k2; \
+        v0          = flag ? v1 : v2; \
+    }
+
+#define WARPMINIMUM2(tgx, v0, k0) \
+    WARPMINIMUMEXCHANGE(tgx, v0, k0, 1) \
+    WARPMINIMUMEXCHANGE(tgx, v0, k0, 2) \
+    WARPMINIMUMEXCHANGE(tgx, v0, k0, 4) \
+    WARPMINIMUMEXCHANGE(tgx, v0, k0, 8) \
+    WARPMINIMUMEXCHANGE(tgx, v0, k0, 16)   
+
+#define REDUCEINTEGERSUM(value, pAccumulator) \
+    if (threadIdx.x == 0) \
+    { \
+        *pAccumulator = 0; \
+    } \
+    __threadfence(); \
+    __syncthreads(); \
+    if (__any_sync(0xffffffff, value != 0)) \
+    { \
+        uint32_t tgx            = threadIdx.x & cData.warpmask; \
+        value                  += __shfl_sync(0xffffffff, value, tgx ^ 1); \
+        value                  += __shfl_sync(0xffffffff, value, tgx ^ 2); \
+        value                  += __shfl_sync(0xffffffff, value, tgx ^ 4); \
+        value                  += __shfl_sync(0xffffffff, value, tgx ^ 8); \
+        value                  += __shfl_sync(0xffffffff, value, tgx ^ 16); \
+        if (tgx == 0) \
+        { \
+            atomicAdd(pAccumulator, value); \
+        } \
+    } \
+    __threadfence(); \
+    __syncthreads(); \
+    value = *pAccumulator; \
+    __syncthreads();
+
+
+#define ATOMICADDF32(pAccumulator, value) atomicAdd(pAccumulator, (value))
+#define ATOMICSUBF32(pAccumulator, value) atomicAdd(pAccumulator, -(value))
+
+
+#define RSCALE  (1ll << 30)
+static const float REDUCESCALEF             = (float)RSCALE;
+static const float ONEOVEREDUCESCALEF       = (float)1.0 / REDUCESCALEF;
+#define REDUCEFLOATSUM(value, pAccumulator) \
+    if (threadIdx.x == 0) \
+    { \
+        *pAccumulator = 0; \
+    } \
+    __threadfence(); \
+    __syncthreads(); \
+    if (__any_sync(0xffffffff, value != 0.0f)) \
+    { \
+        uint32_t tgx            = threadIdx.x & cData.warpmask; \
+        value                  += __shfl_sync(0xffffffff, value, tgx ^ 1); \
+        value                  += __shfl_sync(0xffffffff, value, tgx ^ 2); \
+        value                  += __shfl_sync(0xffffffff, value, tgx ^ 4); \
+        value                  += __shfl_sync(0xffffffff, value, tgx ^ 8); \
+        value                  += __shfl_sync(0xffffffff, value, tgx ^ 16); \
+        if (tgx == 0) \
+        { \
+            atomicAdd(pAccumulator, llitoulli(llrintf(REDUCESCALEF * value))); \
+        } \
+    } \
+    __threadfence(); \
+    __syncthreads(); \
+    value = (float)(*pAccumulator) * ONEOVEREDUCESCALEF; \
+    __syncthreads();
+
+
+
+
+static __constant__ GpuData cData;
+
+void SetKernelsGpuData(GpuData* pData)
+{
+    cudaError_t status;
+    status = cudaMemcpyToSymbol(cData, pData, sizeof(GpuData));
+    RTERROR(status, "SetKernelsGpuData copy to cData failed");
+}
+
+void GetKernelsGpuData(GpuData* pData)
+{
+    cudaError_t status;
+    status = cudaMemcpyFromSymbol(pData, cData, sizeof(GpuData));
+    RTERROR(status, "GetKernelsGpuData copy From cData failed");
+}
+
+
+// Kernel files
+#include "calcenergy.cu"
+#include "calcMergeEneGra.cu"
+#include "auxiliary_genetic.cu"
+#include "kernel1.cu"
+#include "kernel2.cu"
+#include "kernel4.cu"
+#include "kernel_ad.cu"

--- a/cuda/kernels.cu
+++ b/cuda/kernels.cu
@@ -119,5 +119,6 @@ void GetKernelsGpuData(GpuData* pData)
 #include "auxiliary_genetic.cu"
 #include "kernel1.cu"
 #include "kernel2.cu"
+#include "kernel3.cu"
 #include "kernel4.cu"
 #include "kernel_ad.cu"

--- a/device/auxiliary_genetic.cl
+++ b/device/auxiliary_genetic.cl
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/device/calcMergedEneGra.cl
+++ b/device/calcMergedEneGra.cl
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/device/calcenergy.cl
+++ b/device/calcenergy.cl
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/device/calcgradient.cl
+++ b/device/calcgradient.cl
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/device/kernel1.cl
+++ b/device/kernel1.cl
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/device/kernel2.cl
+++ b/device/kernel2.cl
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/device/kernel3.cl
+++ b/device/kernel3.cl
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/device/kernel4.cl
+++ b/device/kernel4.cl
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/device/kernel_ad.cl
+++ b/device/kernel_ad.cl
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/device/kernel_fire.cl
+++ b/device/kernel_fire.cl
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/device/kernel_sd.cl
+++ b/device/kernel_sd.cl
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/host/inc/autostop.hpp
+++ b/host/inc/autostop.hpp
@@ -1,0 +1,193 @@
+#ifndef AUTOSTOP_HPP
+#define AUTOSTOP_HPP
+
+#include <vector>
+#include <cmath>
+#include <stdio.h>
+#include <stdlib.h>
+
+class AutoStop{
+	bool first_time;
+	bool autostopped;
+        float threshold;
+        float threshold_used;
+        float thres_stddev;
+        float curr_avg;
+        float curr_std;
+        unsigned int roll_count;
+        float rolling_stddev;
+        unsigned int bestN;
+        const unsigned int Ntop;
+	const unsigned int pop_size;
+	const int num_of_runs;
+	const float stopstd;
+        const unsigned int Ncream;
+        float delta_energy;
+        float overall_best_energy;
+	std::vector<float> rolling;
+	std::vector<float> average_sd2_N;
+
+	inline float average(float* average_sd2_N)
+	{
+		if(average_sd2_N[2]<1.0f)
+			return 0.0;
+		return average_sd2_N[0]/average_sd2_N[2];
+	}
+
+	inline float stddev(float* average_sd2_N)
+	{
+		if(average_sd2_N[2]<1.0f)
+			return 0.0;
+		float sq = average_sd2_N[1]*average_sd2_N[2]-average_sd2_N[0]*average_sd2_N[0];
+		if((fabs(sq)<=0.000001) || (sq<0.0)) return 0.0;
+		return sqrt(sq)/average_sd2_N[2];
+	}
+
+	inline void tabulate_energies(const float* energies){
+		overall_best_energy = 1<<24;
+		for (unsigned long run_cnt=0; run_cnt < num_of_runs; run_cnt++) {
+			for (unsigned int i=0; i<pop_size; i++) {
+				float energy = energies[run_cnt*pop_size + i];
+				if(energy < overall_best_energy)
+					overall_best_energy = energy;
+				if(energy < threshold) {
+					average_sd2_N[0] += energy;
+					average_sd2_N[1] += energy * energy;
+					average_sd2_N[2] += 1.0;
+					for(unsigned int m=0; m<Ntop; m++)
+						if(energy < (threshold-2.0*thres_stddev)+m*delta_energy) {
+							average_sd2_N[3*(m+1)] += energy;
+							average_sd2_N[3*(m+1)+1] += energy*energy;
+							average_sd2_N[3*(m+1)+2] += 1.0;
+							break; // only one entry per bin
+						}
+				}
+			}
+		}
+	}
+
+	inline void set_stats(){
+		curr_avg = average(&average_sd2_N[0]);
+		curr_std = stddev(&average_sd2_N[0]);
+		bestN = average_sd2_N[2];
+		average_sd2_N[0] = 0.0;
+		average_sd2_N[1] = 0.0;
+		average_sd2_N[2] = 0.0;
+		unsigned int lowest_energy = 0;
+		for(unsigned int m=0; m<Ntop; m++) {
+			if((average_sd2_N[3*(m+1)+2]>=1.0) && (lowest_energy<Ncream)) {
+				if((average_sd2_N[2]<4.0) || fabs(average(&average_sd2_N[0])-average(&average_sd2_N[3*(m+1)]))<2.0*stopstd) {
+					average_sd2_N[0] += average_sd2_N[3*(m+1)];
+					average_sd2_N[1] += average_sd2_N[3*(m+1)+1];
+					average_sd2_N[2] += average_sd2_N[3*(m+1)+2];
+					lowest_energy++;
+				}
+			}
+		}
+
+		if(lowest_energy>0) {
+			curr_avg = average(&average_sd2_N[0]);
+			curr_std = stddev(&average_sd2_N[0]);
+			bestN = average_sd2_N[2];
+		}
+	}
+
+	public:
+
+	AutoStop(int pop_size_in, int num_of_runs_in, float stopstd_in)
+		: rolling(4*3, 0), // Initialize to zero
+		  average_sd2_N((pop_size_in+1)*3),
+		  num_of_runs(num_of_runs_in),
+		  pop_size(pop_size_in),
+		  Ntop(pop_size_in),
+		  Ncream(pop_size_in / 10),
+		  stopstd(stopstd_in)
+	{
+		first_time = true;
+		autostopped = false;
+		threshold = 1<<24;
+		thres_stddev = threshold;
+		curr_avg = -(1<<24);
+		curr_std = thres_stddev;
+		roll_count = 0;
+		bestN = 1;
+		delta_energy = 2.0 * thres_stddev / Ntop;
+	}
+
+	inline void print_intro(unsigned long num_of_generations, unsigned long num_of_energy_evals)
+	{
+		printf("\nExecuting docking runs, stopping automatically after either reaching %.2f kcal/mol standard deviation\nof the best molecules, %lu generations, or %lu evaluations, whichever comes first:\n\n",stopstd,num_of_generations,num_of_energy_evals);
+                printf("Generations |  Evaluations |     Threshold    |  Average energy of best 10%%  | Samples |    Best energy\n");
+                printf("------------+--------------+------------------+------------------------------+---------+-------------------\n");
+	}
+
+	inline bool check_if_satisfactory(int generation_cnt, const float* energies, unsigned long total_evals)
+	{
+		for(unsigned int count=0; (count<1+8*(generation_cnt==0)) && (fabs(curr_avg)>0.00001); count++)
+		{
+			threshold_used = threshold;
+			std::fill(average_sd2_N.begin(), average_sd2_N.end(), 0); // reset to 0
+			tabulate_energies(energies); // Fills average_sd2_N and overall_best_energy
+			if(first_time)
+			{
+				curr_avg = average(&average_sd2_N[0]);
+				curr_std = stddev(&average_sd2_N[0]);
+				bestN = average_sd2_N[2];
+				thres_stddev = curr_std;
+				threshold = curr_avg + thres_stddev;
+				delta_energy = 2.0 * thres_stddev / (Ntop-1);
+				first_time = false;
+			}
+			else
+			{
+				set_stats(); // set curr_avg, curr_std, bestN, average_sd2_N 
+
+				if(curr_std<0.5f*stopstd)
+					thres_stddev = stopstd;
+				else
+					thres_stddev = curr_std;
+				threshold = curr_avg + Ncream * thres_stddev / bestN;
+				delta_energy = 2.0 * thres_stddev / (Ntop-1);
+			}
+		}
+		printf("%11u | %12lu |%8.2f kcal/mol |%8.2f +/-%8.2f kcal/mol |%8i |%8.2f kcal/mol\n",generation_cnt,total_evals/num_of_runs,threshold_used,curr_avg,curr_std,bestN,overall_best_energy);
+		fflush(stdout);
+		rolling[3*roll_count] = curr_avg * bestN;
+		rolling[3*roll_count+1] = (curr_std*curr_std + curr_avg*curr_avg)*bestN;
+		rolling[3*roll_count+2] = bestN;
+		roll_count = (roll_count + 1) % 4;
+		average_sd2_N[0] = rolling[0] + rolling[3] + rolling[6] + rolling[9];
+		average_sd2_N[1] = rolling[1] + rolling[4] + rolling[7] + rolling[10];
+		average_sd2_N[2] = rolling[2] + rolling[5] + rolling[8] + rolling[11];
+
+		// Finish when the std.dev. of the last 4 rounds is below 0.1 kcal/mol
+		if((stddev(&average_sd2_N[0])<stopstd) && (generation_cnt>30))
+			autostopped = true;
+
+		return autostopped;
+	}
+
+	inline void output_final_stddev(int generation_cnt, const float* energies, unsigned long total_evals){
+		if (autostopped){
+			printf("------------+--------------+------------------+------------------------------+---------+-------------------\n");
+			printf("\n%43s evaluation after reaching\n%40.2f +/-%8.2f kcal/mol combined.\n%34i samples, best energy %8.2f kcal/mol.\n","Finished",average(&average_sd2_N[0]),stddev(&average_sd2_N[0]),(unsigned int)average_sd2_N[2],overall_best_energy);
+		} else {
+			// Stopped without autostop; output stddev statistics regardless
+
+			tabulate_energies(energies);  // Fills average_sd2_N and overall_best_energy
+			set_stats(); // set curr_avg, curr_std, bestN, average_sd2_N
+
+			printf("%11u | %12u |%8.2f kcal/mol |%8.2f +/-%8.2f kcal/mol |%8i |%8.2f kcal/mol\n",generation_cnt,total_evals/num_of_runs,threshold,curr_avg,curr_std,bestN,overall_best_energy);
+			printf("------------+--------------+------------------+------------------------------+---------+-------------------\n");
+			printf("\n%43s evaluation after reaching\n%33u evaluations. Best energy %8.2f kcal/mol.\n","Finished",total_evals/num_of_runs,overall_best_energy);
+		}
+		fflush(stdout);
+	}
+
+	inline bool did_stop(){
+		return autostopped;
+	}
+
+};
+
+#endif

--- a/host/inc/calcenergy.h
+++ b/host/inc/calcenergy.h
@@ -30,6 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include <math.h>
 #include <stdio.h>
+#include <cstdint>
 
 #include "calcenergy_basic.h"
 #include "miscellaneous.h"
@@ -126,13 +127,13 @@ typedef struct
 
 typedef struct
 {
-       float atom_charges_const[MAX_NUM_OF_ATOMS];
-       char  atom_types_const  [MAX_NUM_OF_ATOMS];
+       float     atom_charges_const[MAX_NUM_OF_ATOMS];
+       uint32_t  atom_types_const  [MAX_NUM_OF_ATOMS];
 } kernelconstant_interintra;
 
 typedef struct
 {
-       char  intraE_contributors_const[3*MAX_INTRAE_CONTRIBUTORS];
+       uint32_t  intraE_contributors_const[3*MAX_INTRAE_CONTRIBUTORS];
 } kernelconstant_intracontrib;
 
 typedef struct

--- a/host/inc/calcenergy.h
+++ b/host/inc/calcenergy.h
@@ -25,6 +25,24 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef CALCENERGY_H_
 #define CALCENERGY_H_
 

--- a/host/inc/correct_grad_axisangle.h
+++ b/host/inc/correct_grad_axisangle.h
@@ -24,6 +24,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
 /* 
 Gradient corrections 
 The corrections for dE/d_phi depend on two variables: rotangle and theta. 

--- a/host/inc/filelist.hpp
+++ b/host/inc/filelist.hpp
@@ -1,0 +1,24 @@
+#ifndef FILELIST_HPP
+#define FILELIST_HPP
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <vector>
+
+class FileList{
+
+	public:
+
+	bool used;
+	char filename [128];
+	int nfiles;
+	std::vector<std::string> resnames;
+	std::vector<std::string> fld_files;
+	std::vector<std::string> ligand_files;
+
+	// Default to unused, with 1 file
+	FileList() : used( false ), nfiles( 1 ){}
+};
+
+#endif

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -37,12 +37,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <math.h>
 #include <string.h>
 #include <stdio.h>
+#include <vector>
 
 #include "defines.h"
 #include "processligand.h"
 #include "processgrid.h"
 #include "miscellaneous.h"
 #include "calcenergy_basic.h"
+#include "filelist.hpp"
 
 typedef struct
 {
@@ -60,6 +62,7 @@ typedef struct
 	unsigned long num_of_generations;
 		bool nev_provided;
 		bool use_heuristics;
+	unsigned long max_num_of_energy_evals;
 		float abs_max_dmov;
 		float abs_max_dang;
 		float mutation_rate;
@@ -101,9 +104,14 @@ typedef struct
         float adam_epsilon;
 } Dockpars;
 
+int get_filelist(const int* argc,
+                      char** argv,
+		     FileList& filelist);
+
 int get_filenames_and_ADcoeffs(const int*,
 			           char**,
-				Dockpars*);
+				Dockpars*,
+				const bool);
 
 void get_commandpars(const int*,
 		         char**,

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -96,6 +96,9 @@ typedef struct
 		char  resname [128];
 		float qasp;
 		float rmsd_tolerance;
+        float adam_beta1;
+        float adam_beta2;
+        float adam_epsilon;
 } Dockpars;
 
 int get_filenames_and_ADcoeffs(const int*,

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -25,6 +25,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
 #ifndef GETPARAMETERS_H_
 #define GETPARAMETERS_H_
 

--- a/host/inc/miscellaneous.h
+++ b/host/inc/miscellaneous.h
@@ -25,6 +25,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
 #ifndef MISCELLANEOUS_H_
 #define MISCELLANEOUS_H_
 

--- a/host/inc/performdocking.h
+++ b/host/inc/performdocking.h
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <cuda_runtime_api.h>
 #include <cassert>
 
-
+#include "profile.hpp"
 
 //#include <math.h>
 #include "processgrid.h"
@@ -70,9 +70,9 @@ int docking_with_gpu(const Gridinfo* 		mygrid,
 		           Dockpars*		mypars,
 		     const Liganddata* 	 	myligand_init,
 		     const Liganddata* 		myxrayligand,
+                        Profile&                profile,
 		     const int* 		argc,
-		     char**			argv,
-		           clock_t 		clock_start_program);
+		     char**			argv);
 
 double check_progress(int* evals_of_runs,
 		      int generation_cnt,

--- a/host/inc/performdocking.h
+++ b/host/inc/performdocking.h
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/host/inc/performdocking.h
+++ b/host/inc/performdocking.h
@@ -66,6 +66,10 @@ typedef struct {
 } Gradientparameters;
 #endif
 
+void setup_gpu_for_docking(GpuData& cData, 
+                           GpuTempData& tData);
+void finish_gpu_from_docking(GpuData& cData, 
+                             GpuTempData& tData);
 int docking_with_gpu(const Gridinfo* 		mygrid,
          	     /*const*/ float* 		cpu_floatgrids,
 		           Dockpars*		mypars,
@@ -74,7 +78,9 @@ int docking_with_gpu(const Gridinfo* 		mygrid,
                         Profile&                profile,
 		     const int* 		argc,
 		     char**			argv,
-			SimulationState&	sim_state);
+			SimulationState&	sim_state,
+			GpuData& cData,
+			GpuTempData& tData);
 
 double check_progress(int* evals_of_runs,
 		      int generation_cnt,

--- a/host/inc/performdocking.h
+++ b/host/inc/performdocking.h
@@ -31,31 +31,22 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-//#include <math.h>
+#include <cuda.h>
+#include <curand.h>
+#include <cuda_runtime_api.h>
+#include <cassert>
 
+
+
+//#include <math.h>
 #include "processgrid.h"
 #include "miscellaneous.h"
 #include "processligand.h"
 #include "getparameters.h"
 #include "calcenergy.h"
 #include "processresult.h"
+#include "GpuData.h"
 
-#ifdef __APPLE__
-	#include "OpenCL/opencl.h"
-#else
-	#include "CL/opencl.h"
-#endif
-#include "commonMacros.h"
-#include "listAttributes.h"
-#include "Platforms.h"
-#include "Devices.h"
-#include "Contexts.h"
-#include "CommandQueues.h"
-#include "Programs.h"
-#include "Kernels.h"
-#include "ImportBinary.h"
-#include "ImportSource.h"
-#include "BufferObjects.h"
 
 #define ELAPSEDSECS(stop,start) ((float) stop-start)/((float) CLOCKS_PER_SEC)
 

--- a/host/inc/processgrid.h
+++ b/host/inc/processgrid.h
@@ -81,7 +81,7 @@ typedef struct
 int get_gridinfo(const char*, Gridinfo*);
 
 int get_gridvalues_f(const Gridinfo* mygrid,
-		     float** fgrids,
+		     float* fgrids,
 		     bool cgmaps);
 
 #endif /* PROCESSGRID_H_ */

--- a/host/inc/processgrid.h
+++ b/host/inc/processgrid.h
@@ -25,6 +25,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
 #ifndef PROCESSGRID_H_
 #define PROCESSGRID_H_
 

--- a/host/inc/processligand.h
+++ b/host/inc/processligand.h
@@ -25,6 +25,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
 #ifndef PROCESSLIGAND_H_
 #define PROCESSLIGAND_H_
 

--- a/host/inc/processligand.h
+++ b/host/inc/processligand.h
@@ -136,7 +136,7 @@ int get_bonds(Liganddata*);
 
 int get_VWpars(Liganddata*, const double, const double);
 
-void get_moving_and_unit_vectors(Liganddata*);
+int get_moving_and_unit_vectors(Liganddata*);
 
 int get_liganddata(const char*, Liganddata*, const double, const double);
 

--- a/host/inc/processresult.h
+++ b/host/inc/processresult.h
@@ -114,7 +114,6 @@ void clusanal_gendlg(Ligandresult myresults [],
 		     const int*        argc,
                                char**  argv,
                      const double docking_avg_runtime,
-		     const double program_runtime,
 		     unsigned long generations_used,
 		     unsigned long evals_performed);
 

--- a/host/inc/processresult.h
+++ b/host/inc/processresult.h
@@ -41,6 +41,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "defines.h"
 #include "processligand.h"
 #include "getparameters.h"
+#include "simulation_state.hpp"
 
 #define PRINT1000(file, x) fprintf(file,  ((fabs((x)) >= 0.0) && ((fabs(x)) <= 1000.)) ? "%+7.2f" : "%+11.2e" , (x));
 
@@ -115,6 +116,17 @@ void clusanal_gendlg(Ligandresult myresults [],
                                char**  argv,
                      const double docking_avg_runtime,
 		     unsigned long generations_used,
-		     unsigned long evals_performed);
+		     unsigned long evals_performed,
+		     double exec_time,
+		     double idle_time);
+
+void process_result(    const Gridinfo*         mygrid, 
+                        const float*            cpu_floatgrids,
+                        const Dockpars*         mypars,
+                        const Liganddata*       myligand_init,
+                        const Liganddata*       myxrayligand,
+                        const int*              argc,
+                        char**                  argv,
+			SimulationState&        sim_state);
 
 #endif /* PROCESSRESULT_H_ */

--- a/host/inc/processresult.h
+++ b/host/inc/processresult.h
@@ -25,6 +25,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
 #ifndef PROCESSRESULT_H_
 #define PROCESSRESULT_H_
 

--- a/host/inc/profile.hpp
+++ b/host/inc/profile.hpp
@@ -1,0 +1,34 @@
+#ifndef PROFILE_HPP
+#define PROFILE_HPP
+
+#include <string.h>
+#include <vector>
+#include <cmath>
+
+struct Profile{
+	public:
+	int id;
+	bool adadelta;
+	int n_evals;
+	bool capped;
+	bool autostopped;
+	int nev_at_stop;
+	int num_atoms;
+	int num_rotbonds;
+	float exec_time;
+
+	Profile(const int id_in) : id(id_in), capped(false), autostopped(false) {}
+
+	void write_to_file(char* filename){
+		char profile_file_name[256];
+		strcpy(profile_file_name, filename);
+		strcat(profile_file_name, ".timing");
+		FILE* fp = fopen(profile_file_name, "a");
+		if (id==0) fprintf(fp, "ID ADADELTA n_evals capped autostopped nev_at_stop num_atoms num_rotbonds exec_time");
+		fprintf(fp, "\n%d %d %d %d %d %d %d %d %.3f", id, adadelta?1:0, n_evals, capped?1:0, autostopped, nev_at_stop, num_atoms, num_rotbonds, exec_time );
+		fclose(fp);
+	}
+
+};
+
+#endif

--- a/host/inc/profile.hpp
+++ b/host/inc/profile.hpp
@@ -17,18 +17,29 @@ struct Profile{
 	int num_rotbonds;
 	float exec_time;
 
-	Profile(const int id_in) : id(id_in), capped(false), autostopped(false) {}
+	Profile(const int id_in) : id(id_in), capped(false), autostopped(false), exec_time(-1.0f) {}
 
-	void write_to_file(char* filename){
-		char profile_file_name[256];
-		strcpy(profile_file_name, filename);
-		strcat(profile_file_name, ".timing");
-		FILE* fp = fopen(profile_file_name, "a");
-		if (id==0) fprintf(fp, "ID ADADELTA n_evals capped autostopped nev_at_stop num_atoms num_rotbonds exec_time");
-		fprintf(fp, "\n%d %d %d %d %d %d %d %d %.3f", id, adadelta?1:0, n_evals, capped?1:0, autostopped, nev_at_stop, num_atoms, num_rotbonds, exec_time );
-		fclose(fp);
+	void write_to_file(FILE* fp){
+		int success = (exec_time>=0.0f ? 1 : 0);
+                float real_exec_time = (exec_time>=0.0f ? exec_time : 0.0f);
+                fprintf(fp, "\n%d %d %d %d %d %d %d %d %d %.3f", id, adadelta?1:0, n_evals, capped?1:0, autostopped, nev_at_stop, num_atoms, num_rotbonds, success, real_exec_time );
 	}
-
 };
 
+class Profiler{
+	public:
+	std::vector<Profile> p;
+
+	void write_profiles_to_file(char* filename){
+		char profile_file_name[256];
+	        strcpy(profile_file_name, filename);
+	        strcat(profile_file_name, ".timing");
+	        FILE* fp = fopen(profile_file_name, "a");
+	        fprintf(fp, "ID ADADELTA n_evals capped autostopped nev_at_stop num_atoms num_rotbonds successful exec_time");
+		for (int i=0;i<p.size();i++){
+		        p[i].write_to_file(fp);
+		}
+	        fclose(fp);
+	}
+};
 #endif

--- a/host/inc/setup.hpp
+++ b/host/inc/setup.hpp
@@ -1,0 +1,51 @@
+/*
+
+AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian Genetic Algorithm
+Copyright (C) 2017 TU Darmstadt, Embedded Systems and Applications Group, Germany. All rights reserved.
+For some of the code, Copyright (C) 2019 Computational Structural Biology Center, the Scripps Research Institute.
+
+AutoDock is a Trade Mark of the Scripps Research Institute.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+
+
+
+#ifndef SETUP_HPP
+#define SETUP_HPP
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "processgrid.h"
+#include "miscellaneous.h"
+#include "processligand.h"
+#include "getparameters.h"
+
+
+int setup(Gridinfo&		mygrid,
+	  std::vector<float>& floatgrids,
+	  Dockpars&		mypars,
+	  Liganddata&		myligand_init,
+	  Liganddata&		myxrayligand,
+	  FileList&             filelist,
+	  int 	                i_file,
+	  int			argc,
+	  char*			argv[]);
+
+#endif

--- a/host/inc/simulation_state.hpp
+++ b/host/inc/simulation_state.hpp
@@ -25,8 +25,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 
 
-#ifndef PERFORMDOCKING_H_
-#define PERFORMDOCKING_H_
+#ifndef SIMULATION_STATE_HPP
+#define SIMULATION_STATE_HPP
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -45,42 +45,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "getparameters.h"
 #include "calcenergy.h"
 #include "processresult.h"
-#include "simulation_state.hpp"
-#include "GpuData.h"
 
+struct SimulationState{
+	std::vector<float>	cpu_populations;
+	std::vector<float>	cpu_energies;
+	Liganddata       	myligand_reference;
+	std::vector<int>	cpu_evals_of_runs;
+	int                     generation_cnt;
+	std::vector<float>	cpu_ref_ori_angles;
+	float                   sec_per_run;
+	unsigned long           total_evals;
+	double			exec_time;
+	double			idle_time;
+};
 
-#define ELAPSEDSECS(stop,start) ((float) stop-start)/((float) CLOCKS_PER_SEC)
-
-#if 0
-// Experimental TSRI gradient-based minimizer kernel argument
-// Setup here (temporarily?) the gradient-based minimizer and associated parameters.
-// This should be ultimately configurable by the user as program exec. flags.
-
-typedef struct {
-	unsigned int max_num_of_iters;
-	/*
-	unsigned int max_num_of_consec_fails;
-	float alpha;
-	float conformation_min_perturbation [ACTUAL_GENOTYPE_LENGTH];
-	*/
-} Gradientparameters;
 #endif
-
-int docking_with_gpu(const Gridinfo* 		mygrid,
-         	     /*const*/ float* 		cpu_floatgrids,
-		           Dockpars*		mypars,
-		     const Liganddata* 	 	myligand_init,
-		     const Liganddata* 		myxrayligand,
-                        Profile&                profile,
-		     const int* 		argc,
-		     char**			argv,
-			SimulationState&	sim_state);
-
-double check_progress(int* evals_of_runs,
-		      int generation_cnt,
-		      int max_num_of_evals,
-		      int max_num_of_gens,
-		      int num_of_runs,
-		      unsigned long &total_evals);
-
-#endif /* PERFORMDOCKING_H_ */

--- a/host/src/calcenergy.cpp
+++ b/host/src/calcenergy.cpp
@@ -279,7 +279,7 @@ int prepare_const_fields_for_gpu(Liganddata* 	   		myligand_reference,
 
 
 	//reference orientation quaternions
-	for (i=0; i<mypars->num_of_runs; i++)
+	for (uint32_t i=0; i<mypars->num_of_runs; i++)
 	{
 		//printf("Pregenerated angles for run %d: %f %f %f\n", i, cpu_ref_ori_angles[3*i], cpu_ref_ori_angles[3*i+1], cpu_ref_ori_angles[3*i+2]);
 
@@ -467,7 +467,7 @@ int gen_rotlist(Liganddata* myligand, int rotlist[MAX_NUM_OF_ROTATIONS])
 	char atom_wasnt_rotated_yet[MAX_NUM_OF_ATOMS];
 	int new_rotlist_element;
 	char rotbond_found;
-	char rotbond_candidate;
+	int rotbond_candidate;
 	char remaining_rots_around_rotbonds;
 
 

--- a/host/src/calcenergy.cpp
+++ b/host/src/calcenergy.cpp
@@ -25,6 +25,26 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include "calcenergy.h"
 
 /*

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -418,7 +418,7 @@ void get_commandpars(const int* argc,
 			else if (strcmp(temp, "ad") == 0) {
 				strcpy(mypars->ls_method, temp);
 				//mypars->max_num_of_iters = 30;
-			} if (strcmp(temp, "adam") == 0) {
+			} else if (strcmp(temp, "adam") == 0) {
 				strcpy(mypars->ls_method, temp);
 				//mypars->max_num_of_iters = 30;
 			}

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -150,19 +150,23 @@ void get_commandpars(const int* argc,
 	mypars->mutation_rate		= 2; 		// 2%
 	mypars->crossover_rate		= 80;		// 80%
 	mypars->lsearch_rate		= 80;		// 80%
+    mypars->adam_beta1          = 0.9f;
+    mypars->adam_beta2          = 0.999f;
+    mypars->adam_epsilon        = 1.0e-8f;    
 				    // unsigned long num_of_ls
 
 	strcpy(mypars->ls_method, "sw");		// "sw": Solis-Wets, 
 							// "sd": Steepest-Descent
 							// "fire": FIRE, https://www.math.uni-bielefeld.de/~gaehler/papers/fire.pdf
 							// "ad": ADADELTA, https://arxiv.org/abs/1212.5701
+                            // "adam": ADAM, 
 	mypars->smooth			= 0.5f;
 	mypars->tournament_rate		= 60;		// 60%
 	mypars->rho_lower_bound		= 0.01;		// 0.01
 	mypars->base_dmov_mul_sqrt3	= 2.0/(*spacing)*sqrt(3.0);	// 2 A
 	mypars->base_dang_mul_sqrt3	= 75.0*sqrt(3.0);		// 75°
 	mypars->cons_limit		= 4;		// 4
-	mypars->max_num_of_iters	= 300;
+	mypars->max_num_of_iters	= 300; //300;
 	mypars->pop_size		= 150;
 	mypars->initpop_gen_or_loadfile	= 0;
 	mypars->gen_pdbs		= 0;
@@ -320,6 +324,7 @@ void get_commandpars(const int* argc,
 		// "sd": Steepest-Descent
 		// "fire": FIRE
 		// "ad": ADADELTA
+        // "adam" : ADAM
 		if (strcmp("-lsmet", argv [i]) == 0)
 		{
 			arg_recognized = 1;
@@ -341,6 +346,9 @@ void get_commandpars(const int* argc,
 				//mypars->max_num_of_iters = 30;
 			}
 			else if (strcmp(temp, "ad") == 0) {
+				strcpy(mypars->ls_method, temp);
+				//mypars->max_num_of_iters = 30;
+			} if (strcmp(temp, "adam") == 0) {
 				strcpy(mypars->ls_method, temp);
 				//mypars->max_num_of_iters = 30;
 			}

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -26,6 +26,29 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <cstdint>
 #include "getparameters.h"
 #include <fstream>
+#include <algorithm> 
+#include <cctype>
+#include <locale>
+
+// trim from start (in place)
+static inline void ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) {
+        return !std::isspace(ch);
+    }));
+}
+
+// trim from end (in place)
+static inline void rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) {
+        return !std::isspace(ch);
+    }).base(), s.end());
+}
+
+// trim from both ends (in place)
+static inline void trim(std::string &s) {
+    ltrim(s);
+    rtrim(s);
+}
 
 int get_filelist(const int* argc,
                       char** argv,
@@ -45,9 +68,14 @@ int get_filelist(const int* argc,
 
 	if (filelist.used){
 		std::ifstream file(filelist.filename);
+		if(file.fail()){
+			printf("\nError: Could not open filelist %s. Check path and permissions.",filelist.filename);
+			return 1;
+		}
 		std::string line;
 		bool prev_line_was_fld=false;
 		while(std::getline(file, line)) {
+			trim(line); // Remove leading and trailing whitespace
 			int len = line.size();
 			if (len>=4 && line.compare(len-4,4,".fld") == 0){
 				if (prev_line_was_fld){ // Overwrite the previous fld file if two in a row

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -24,6 +24,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
 #include "getparameters.h"
 
 int get_filenames_and_ADcoeffs(const int* argc,

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
 
-
+#include <cstdint>
 
 
 #include "getparameters.h"
@@ -867,7 +867,7 @@ void gen_initpop_and_reflig(Dockpars*       mypars,
 	//only the required angles are generated here,
 	//but the angles possibly read from file are ignored
 
-	for (i=0; i<mypars->num_of_runs; i++)
+	for (uint32_t i=0; i<mypars->num_of_runs; i++)
 	{
 #if defined (REPRO)
 		ref_ori_angles[3*i]   = 190.279;

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -158,8 +158,10 @@ int main(int argc, char* argv[])
 						// If error encountered: Set error flag to 1; Add to count of finished jobs
 						// Keep in setup stage rather than moving to launch stage so a different job will be set up
 						printf("\n\nError in setup of Job #%d:", i_job);
-                		                printf("\n(   Field file: %s )",  filelist.fld_files[i_job].c_str());
-		                                printf("\n(   Ligand file: %s )", filelist.ligand_files[i_job].c_str()); fflush(stdout);
+						if (filelist.used){
+                		                	printf("\n(   Field file: %s )",  filelist.fld_files[i_job].c_str());
+		                                	printf("\n(   Ligand file: %s )", filelist.ligand_files[i_job].c_str()); fflush(stdout);
+						}
 						err = 1;
 #ifdef USE_PIPELINE
 						#pragma omp atomic update
@@ -206,8 +208,10 @@ int main(int argc, char* argv[])
 				sim_state[i_queue].idle_time = seconds_since(idle_timer);
 				start_timer(exec_timer);
 				printf("\nRunning Job #%d: ", i_job);
-                                printf("\n   Fields from: %s",  filelist.fld_files[i_job].c_str());
-                                printf("\n   Ligands from: %s", filelist.ligand_files[i_job].c_str()); fflush(stdout);
+				if (filelist.used){
+                                	printf("\n   Fields from: %s",  filelist.fld_files[i_job].c_str());
+                                	printf("\n   Ligands from: %s", filelist.ligand_files[i_job].c_str()); fflush(stdout);
+				}
 				// Starting Docking
 				if (docking_with_gpu(&(mygrid[i_queue]), floatgrids[i_queue].data(), &(mypars[i_queue]), &(myligand_init[i_queue]), &(myxrayligand[i_queue]), profiles[(get_profiles ? i_job : 0)], &argc, argv, sim_state[i_queue] ) != 0){
 					// If error encountered: Set error flag to 1; Add to count of finished jobs
@@ -225,7 +229,7 @@ int main(int argc, char* argv[])
 					total_exec_time+=sim_state[i_queue].exec_time;
 					printf("\nJob #%d took %.3f sec after waiting %.3f sec for setup", i_job, sim_state[i_queue].exec_time, sim_state[i_queue].idle_time);
 					start_timer(idle_timer);
-					if (get_profiles){
+					if (get_profiles && filelist.used){
 		                        	// Detailed timing information to .timing
 		                        	profiles[i_job].exec_time = sim_state[i_queue].exec_time;
 		                        	profiles[i_job].write_to_file(filelist.filename);

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -142,8 +142,8 @@ int main(int argc, char* argv[])
 	{
 	int t_id = 0;
 #endif
-    if(t_id!=execution_thread || nthreads==1) { // This thread handles setup and processing
-	setup_gpu_for_docking(cData,tData);
+    if(t_id==execution_thread) { // This thread handles setup and processing
+	  setup_gpu_for_docking(cData,tData);
 	}
 	while (!finished_all){
 		if(t_id!=execution_thread || nthreads==1) { // This thread handles setup and processing
@@ -250,8 +250,8 @@ int main(int argc, char* argv[])
 		}
 		if (n_finished_jobs==n_files) finished_all=true;
 	} // end of while loop
-    if(t_id!=execution_thread || nthreads==1) { // This thread handles setup and processing
-	finish_gpu_from_docking(cData,tData);
+    if(t_id==execution_thread) { // This thread handles setup and processing
+	  finish_gpu_from_docking(cData,tData);
 	}
 	} // end of parallel section
 

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -25,6 +25,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
 //#include <stdio.h>
 //#include <stdlib.h>
 #include <time.h>

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -220,7 +220,7 @@ int main(int argc, char* argv[])
                                 	printf("\n   Ligands from: %s", filelist.ligand_files[i_job].c_str()); fflush(stdout);
 				}
 				// Starting Docking
-				if (docking_with_gpu(&(mygrid[i_queue]), floatgrids[i_queue].data(), &(mypars[i_queue]), &(myligand_init[i_queue]), &(myxrayligand[i_queue]), profiles[(get_profiles ? i_job : 0)], &argc, argv, sim_state[i_queue], cData, tData ) != 0){
+				if (docking_with_gpu(&(mygrid[i_queue]), floatgrids[i_queue].data(), &(mypars[i_queue]), &(myligand_init[i_queue]), &(myxrayligand[i_queue]), profiler.p[(get_profiles ? i_job : 0)], &argc, argv, sim_state[i_queue], cData, tData ) != 0){
 
 					// If error encountered: Set error flag to 1; Add to count of finished jobs
 					// Set back to setup stage rather than moving to processing stage so a different job will be set up

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -40,163 +40,214 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "filelist.hpp"
 #include "setup.hpp"
 #include "profile.hpp"
+#include "simulation_state.hpp"
 
 #ifndef _WIN32
-// ------------------------
 // Time measurement
 #include <sys/time.h>
-// ------------------------
+#endif
 
-inline double seconds_since(timeval& time_start)
+template<typename T>
+inline double seconds_since(T& time_start)
 {
+#ifndef _WIN32
 	timeval time_end;
 	gettimeofday(&time_end,NULL);
         double num_sec     = time_end.tv_sec  - time_start.tv_sec;
         double num_usec    = time_end.tv_usec - time_start.tv_usec;
         return (num_sec + (num_usec/1000000));
-}
+#else
+	return 0.0;
 #endif
+}
+
+template<typename T>
+inline void start_timer(T& time_start)
+{
+#ifndef _WIN32
+	gettimeofday(&time_start,NULL);
+#endif
+}
 
 int main(int argc, char* argv[])
 {
-	FileList filelist;
-	int n_files = 1; // default
-	bool overlap = false; // default
-	int setup_thread = 0; // thread the performs the setup
-	int execution_thread = 0; // thread that performs the execution
-	int err = 0;
-#ifndef _WIN32
-	// Start full timer
-	timeval time_start, loop_time_start;
-	gettimeofday(&time_start,NULL);
-	double exec_time, setup_time;
-	double total_savings=0;
-	double total_could_save=0;
+	// CPU thread setup
+	int nthreads=1;
+#ifdef USE_PIPELINE
+	#pragma omp parallel
+	{nthreads = omp_get_num_threads();}
 #endif
+	int execution_thread=nthreads-1; // Last thread does the execution
+        int nqueues=std::max(nthreads-1,1); // The other threads each get a queue
 
-	// Objects that are arguments of docking_with_gpu
-	// These must each have 2
-	Dockpars   mypars[2];
-	Liganddata myligand_init[2];
-	Gridinfo   mygrid[2];
-	Liganddata myxrayligand[2];
-	std::vector<float> floatgrids[2];
+	// Timer initializations
+#ifndef _WIN32
+	timeval time_start, idle_timer, setup_timer, exec_timer, processing_timer;
+	start_timer(time_start);
+	start_timer(idle_timer);
+#endif
+	double total_setup_time=0;
+	double total_processing_time=0;
+	double total_exec_time=0;
+	double idle_time;
 
-	// Read all the file names if -filelist option is on
+	// File list setup if -filelist option is on
+	FileList filelist;
+	int n_files;
 	if (get_filelist(&argc, argv, filelist) != 0)
 		      return 1;
-
-	// Setup using filelist
 	if (filelist.used){
 		n_files = filelist.nfiles;
 		printf("\nRunning %d jobs in pipeline mode ", n_files);
-#ifdef USE_PIPELINE
-		overlap=true; // Not set up to work with nested OpenMP (yet)
-		execution_thread = 1; // Assign Thread 1 to do the execution
-#endif
+		printf("\nUsing %d threads", nthreads);
+	} else {
+		n_files = 1;
 	}
 
+	// Objects that are arguments of docking_with_gpu
+        Dockpars   mypars[nqueues];
+        Liganddata myligand_init[nqueues];
+        Gridinfo   mygrid[nqueues];
+        Liganddata myxrayligand[nqueues];
+        std::vector<float> floatgrids[nqueues];
+	SimulationState sim_state[nqueues];
+
 	// Set up run profiles for timing
+	bool get_profiles = false; // hard-coded switch to use ALS's job profiler
 	std::vector<Profile> profiles;
+	for (int i=0;i<n_files;i++){
+		profiles.push_back(Profile(i));
+		if (!get_profiles) break; // still create 1 if off
+	}
 
 	// Print version info
 	printf("\nAutoDock-GPU version: %s\n", VERSION);
 
-	for (int i_file=0;i_file<(n_files+1);i_file++){ // one extra iteration since its a pipeline
-		int s_id = i_file % 2;    // Alternate which set is undergoing setup (s_id)
-		int r_id = (i_file+1) %2; // and which is being used in the run (r_id)
-		if (filelist.used) {
-			printf("\n\n-------------------------------------------------------------------");
-			if (i_file<n_files){
-				printf("\n(Prepping Job #%d: )", i_file);
-				printf("\n(   Reading fields: %s )",  filelist.fld_files[i_file].c_str());
-				printf("\n(   Reading ligands: %s )", filelist.ligand_files[i_file].c_str()); fflush(stdout);
-			}
-			if (i_file>0){
-				if (i_file<n_files) printf("\nMeanwhile, running ");
-				if (i_file==n_files) printf("\nRunning ");
-				printf("Job #%d: ", i_file-1);
-				printf("\n   Fields from: %s",  filelist.fld_files[i_file-1].c_str());
-				printf("\n   Ligands from: %s", filelist.ligand_files[i_file-1].c_str()); fflush(stdout);
-			}
-		}
-#ifndef _WIN32
-		// Time measurement: start of loop
-		gettimeofday(&loop_time_start,NULL);
-#endif
-		// Branch into two threads
-		//   setup_thread reads files and prepares the inputs to docking_with_gpu
-		//   execution_thread runs docking_with_gpu
+	bool finished_all=false;
+	std::vector<int> job_in_queue(nqueues,-1);
+	enum Stage { Setup, Launch, Processing }; 
+	std::vector<Stage> stage(nqueues,Setup); // Each queue can be in one of three stages
+	int n_finished_jobs=0;
+	int next_job_to_setup=0;
+	int err = 0;
 #ifdef USE_PIPELINE
-		#pragma omp parallel
-		{
-			int thread_id = omp_get_thread_num();
+	#pragma omp parallel
+	{
+	int t_id = omp_get_thread_num();
 #else
-		{
-			int thread_id = 0;
+	{
+	int t_id = 0;
 #endif
-			// Thread 0 does the setup, unless its the last run (so nothing left to load)
-			if ((thread_id==setup_thread) && i_file<n_files) {
-				// Load files, read inputs, prepare arrays for docking stage
-				if (setup(mygrid[s_id], floatgrids[s_id], mypars[s_id], myligand_init[s_id], myxrayligand[s_id], filelist, i_file, argc, argv) != 0)
-					{printf("\n\nError in setup, stopped job."); err = 1;}
-			}
+	while (!finished_all){
+		if(t_id!=execution_thread || nthreads==1) { // This thread handles setup and processing
+			if (stage[t_id]==Setup && next_job_to_setup<n_files){ // If setup needed
+				int i_job;
+				// Grab the next job in atomic capture so two threads don't set up the same job
+#ifdef USE_PIPELINE
+				#pragma omp atomic capture
+#endif
+				{ i_job=next_job_to_setup; next_job_to_setup++; }
 
-			// Do the execution on thread 1, except on the first iteration since nothing is loaded yet
-			if ((thread_id==execution_thread) && i_file>0) {
-				Profile newprofile(i_file-1);
-				profiles.push_back(newprofile);
+				// Setup the next file in the queue
+				if (i_job<n_files) {
+					printf ("\n(Thread %d is setting up Job %d)",t_id,i_job); fflush(stdout);
+					job_in_queue[t_id]=i_job;
+					start_timer(setup_timer);
+					// Load files, read inputs, prepare arrays for docking stage
+					if (setup(mygrid[t_id], floatgrids[t_id], mypars[t_id], myligand_init[t_id], myxrayligand[t_id], filelist, i_job, argc, argv) != 0) {
+						// If error encountered: Set error flag to 1; Add to count of finished jobs
+						// Keep in setup stage rather than moving to launch stage so a different job will be set up
+						printf("\n\nError in setup of Job #%d:", i_job);
+                		                printf("\n(   Field file: %s )",  filelist.fld_files[i_job].c_str());
+		                                printf("\n(   Ligand file: %s )", filelist.ligand_files[i_job].c_str()); fflush(stdout);
+						err = 1;
+#ifdef USE_PIPELINE
+						#pragma omp atomic update
+#endif
+						n_finished_jobs+=1;
+					} else { // Successful setup
+#ifdef USE_PIPELINE
+						#pragma omp atomic update
+#endif
+						total_setup_time+=seconds_since(setup_timer);
+						stage[t_id]=Launch; // Indicate this queue is ready for use
+					}
+				}
+			}
+			if (stage[t_id]==Processing){ // If ready for processing
+				int i_job = job_in_queue[t_id];
+				printf ("\n(Thread %d is processing Job %d)",t_id,i_job); fflush(stdout);
+
+				start_timer(processing_timer);
+                                process_result(&(mygrid[t_id]), floatgrids[t_id].data(), &(mypars[t_id]), &(myligand_init[t_id]), &(myxrayligand[t_id]), &argc,argv, sim_state[t_id]);
+#ifdef USE_PIPELINE
+				#pragma omp atomic update
+#endif
+				total_processing_time+=seconds_since(processing_timer);
+				stage[t_id]=Setup; // Indicate this queue is ready for use
+#ifdef USE_PIPELINE
+				#pragma omp atomic update
+#endif
+				n_finished_jobs+=1;
+                        }
+		}
+
+		if(t_id==execution_thread) { // This thread handles the GPU
+			// Check if there is a job ready to launch
+			int i_queue=-1;
+			for (int i=0;i<stage.size();i++){
+				if (stage[i]==Launch){
+					i_queue=i;
+					break;
+				}
+			}
+			if (i_queue>=0){
+				int i_job = job_in_queue[i_queue];
+				sim_state[i_queue].idle_time = seconds_since(idle_timer);
+				start_timer(exec_timer);
+				printf("\nRunning Job #%d: ", i_job);
+                                printf("\n   Fields from: %s",  filelist.fld_files[i_job].c_str());
+                                printf("\n   Ligands from: %s", filelist.ligand_files[i_job].c_str()); fflush(stdout);
 				// Starting Docking
-				if (docking_with_gpu(&(mygrid[r_id]), floatgrids[r_id].data(), &(mypars[r_id]), &(myligand_init[r_id]), &(myxrayligand[r_id]), profiles[i_file-1], &argc, argv ) != 0)
-					{printf("\n\nError in docking_with_gpu, stopped job."); err = 1;}
-
-			}
-#ifndef _WIN32
-			if (thread_id==setup_thread && overlap) setup_time = seconds_since(loop_time_start);
-			if (thread_id==execution_thread && overlap) exec_time = seconds_since(loop_time_start);
+				if (docking_with_gpu(&(mygrid[i_queue]), floatgrids[i_queue].data(), &(mypars[i_queue]), &(myligand_init[i_queue]), &(myxrayligand[i_queue]), profiles[(get_profiles ? i_job : 0)], &argc, argv, sim_state[i_queue] ) != 0){
+					// If error encountered: Set error flag to 1; Add to count of finished jobs
+					// Set back to setup stage rather than moving to processing stage so a different job will be set up
+					printf("\n\nError in docking_with_gpu, stopped Job %d.",i_job);
+					err = 1;
+#ifdef USE_PIPELINE
+					#pragma omp atomic update
 #endif
-		} // End of openmp parallel region, implicit thread barrier
-		if (err==1) return 1; // Couldnt return immediately while in parallel region
-
+					n_finished_jobs+=1;
+					stage[i_queue]=Setup;
+				} else { // Successful run
 #ifndef _WIN32
-		// Time measurement of this loop
-		double loop_time = seconds_since(loop_time_start);
-		printf("\nLoop run time %.3f sec \n", loop_time);
-		// Determine overlap savings (no overlap at beginning and end of pipeline)
-		if (overlap && i_file>0 && i_file<n_files){
-			double savings = overlap ? (setup_time + exec_time - loop_time) : 0;
-			total_savings += savings;
-			printf("Savings from overlap: %.3f sec \n", savings);
-			double could_save = setup_time-exec_time;
-			if (could_save>0) {
-				printf("WARNING: Setup time exceeded exec time by %.3f sec - consider adding a second a pipeline\n", could_save);
-				total_could_save += could_save;
-			}
-			printf("Cumulative savings: %.3f sec; Cumulative potential additional savings: %.3f sec", total_savings, total_could_save);
-		}
-
-		if (i_file>0){
-			// Append time information to .dlg file
-			char report_file_name[256];
-			strcpy(report_file_name, mypars[r_id].resname);
-			strcat(report_file_name, ".dlg");
-			FILE* fp = fopen(report_file_name, "a");
-			fprintf(fp, "\n\n\nRun time %.3f sec\n", loop_time);
-			fclose(fp);
-
-			// Detailed timing information to .timing
-			profiles[i_file-1].exec_time = exec_time;
-			profiles[i_file-1].write_to_file(filelist.filename);
-		}
+					sim_state[i_queue].exec_time = seconds_since(exec_timer);
+					total_exec_time+=sim_state[i_queue].exec_time;
+					printf("\nJob #%d took %.3f sec after waiting %.3f sec for setup", i_job, sim_state[i_queue].exec_time, sim_state[i_queue].idle_time);
+					start_timer(idle_timer);
+					if (get_profiles){
+		                        	// Detailed timing information to .timing
+		                        	profiles[i_job].exec_time = sim_state[i_queue].exec_time;
+		                        	profiles[i_job].write_to_file(filelist.filename);
+					}
 #endif
-		if (err==1) return 1;
-	} // end of i_file loop
+					stage[i_queue]=Processing; // Indicate this queue is ready for a new setup
+				}
+			} else { // No job is ready to launch
+				// Wait
+			}
+		}
+		if (n_finished_jobs==n_files) finished_all=true;
+	} // end of while loop
+	} // end of parallel section
 
 #ifndef _WIN32
 	// Total time measurement
 	printf("\nRun time of entire job set (%d files): %.3f sec", n_files, seconds_since(time_start));
-	if (overlap) printf("\nTotal savings from overlap: %.3f sec \n\n", total_savings); 
+	printf("\nSavings from pipelining: %.3f sec",(total_setup_time+total_processing_time+total_exec_time) - seconds_since(time_start));
+	printf("\nIdle time of execution thread: %.3f sec",seconds_since(time_start) - total_exec_time);
 #endif
+	if (err==1) printf("\nWARNING: Not all jobs were successful. Search output for 'Error' for details.");
 
 	return 0;
 }

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -41,6 +41,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "setup.hpp"
 #include "profile.hpp"
 #include "simulation_state.hpp"
+#include "GpuData.h"
 
 #ifndef _WIN32
 // Time measurement
@@ -105,12 +106,14 @@ int main(int argc, char* argv[])
 	}
 
 	// Objects that are arguments of docking_with_gpu
-        Dockpars   mypars[nqueues];
-        Liganddata myligand_init[nqueues];
-        Gridinfo   mygrid[nqueues];
-        Liganddata myxrayligand[nqueues];
-        std::vector<float> floatgrids[nqueues];
+    Dockpars   mypars[nqueues];
+    Liganddata myligand_init[nqueues];
+    Gridinfo   mygrid[nqueues];
+    Liganddata myxrayligand[nqueues];
+    std::vector<float> floatgrids[nqueues];
 	SimulationState sim_state[nqueues];
+	GpuData cData;
+	GpuTempData tData;
 
 	// Set up run profiles for timing
 	bool get_profiles = true; // hard-coded switch to use ALS's job profiler
@@ -130,6 +133,7 @@ int main(int argc, char* argv[])
 	int n_finished_jobs=0;
 	int next_job_to_setup=0;
 	int err = 0;
+
 #ifdef USE_PIPELINE
 	#pragma omp parallel
 	{
@@ -138,6 +142,9 @@ int main(int argc, char* argv[])
 	{
 	int t_id = 0;
 #endif
+    if(t_id!=execution_thread || nthreads==1) { // This thread handles setup and processing
+	setup_gpu_for_docking(cData,tData);
+	}
 	while (!finished_all){
 		if(t_id!=execution_thread || nthreads==1) { // This thread handles setup and processing
 			if (stage[t_id]==Setup && next_job_to_setup<n_files){ // If setup needed
@@ -213,7 +220,8 @@ int main(int argc, char* argv[])
                                 	printf("\n   Ligands from: %s", filelist.ligand_files[i_job].c_str()); fflush(stdout);
 				}
 				// Starting Docking
-				if (docking_with_gpu(&(mygrid[i_queue]), floatgrids[i_queue].data(), &(mypars[i_queue]), &(myligand_init[i_queue]), &(myxrayligand[i_queue]), profiler.p[(get_profiles ? i_job : 0)], &argc, argv, sim_state[i_queue] ) != 0){
+				if (docking_with_gpu(&(mygrid[i_queue]), floatgrids[i_queue].data(), &(mypars[i_queue]), &(myligand_init[i_queue]), &(myxrayligand[i_queue]), profiles[(get_profiles ? i_job : 0)], &argc, argv, sim_state[i_queue], cData, tData ) != 0){
+
 					// If error encountered: Set error flag to 1; Add to count of finished jobs
 					// Set back to setup stage rather than moving to processing stage so a different job will be set up
 					printf("\n\nError in docking_with_gpu, stopped Job %d.",i_job);
@@ -242,6 +250,9 @@ int main(int argc, char* argv[])
 		}
 		if (n_finished_jobs==n_files) finished_all=true;
 	} // end of while loop
+    if(t_id!=execution_thread || nthreads==1) { // This thread handles setup and processing
+	finish_gpu_from_docking(cData,tData);
+	}
 	} // end of parallel section
 
 #ifndef _WIN32

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
 	FILE*      fp;
 	char report_file_name [256];
 
-	clock_t clock_start_program, clock_stop_program;
+	clock_t clock_start_program; //, clock_stop_program;
 	clock_start_program = clock();
 
 #ifndef _WIN32
@@ -77,14 +77,14 @@ int main(int argc, char* argv[])
 	// since we need it at grid creation time
 	//------------------------------------------------------------
 	mypars.cgmaps = 0; // default is 0 (use one maps for every CGx or Gx atom types, respectively)
-	for (unsigned int i=1; i<argc-1; i+=2)
+	for (int i=1; i<argc-1; i+=2)
 	{
 		// ----------------------------------
 		//Argument: Use individual maps for CG-G0 instead of the same one
 		if (strcmp("-cgmaps", argv [i]) == 0)
 		{
 			int tempint;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 			if (tempint == 0)
 				mypars.cgmaps = 0;
 			else

--- a/host/src/miscellaneous.cpp
+++ b/host/src/miscellaneous.cpp
@@ -25,6 +25,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
 #include "miscellaneous.h"
 
 int float2fracint(double toconv, int frac)

--- a/host/src/miscellaneous.cpp
+++ b/host/src/miscellaneous.cpp
@@ -68,7 +68,11 @@ double myrand(void)
 
 	if (first_call == 0)
 	{
+#if defined(REPRO)
+        srand(12345);
+#else
 		srand((unsigned int) time(NULL));
+#endif
 		first_call++;
 	}
 

--- a/host/src/performdocking.cpp
+++ b/host/src/performdocking.cpp
@@ -6,19 +6,19 @@ For some of the code, Copyright (C) 2019 Computational Structural Biology Center
 
 AutoDock is a Trade Mark of the Scripps Research Institute.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 

--- a/host/src/performdocking.cpp
+++ b/host/src/performdocking.cpp
@@ -790,6 +790,7 @@ filled with clock() */
 					printf("%-25s", "\tK_LS_GRAD_ADADELTA");fflush(stdout);
 				#endif
                 // runKernel1D(command_queue,kernel7,kernel7_gxsize,kernel7_lxsize,&time_start_kernel,&time_end_kernel);
+                gpu_gradient_minAD(kernel7_gxsize, kernel7_lxsize, pMem_conformations_next, pMem_energies_next);
 				#ifdef DOCK_DEBUG
 					printf("%15s" ," ... Finished\n");fflush(stdout);
 				#endif

--- a/host/src/performdocking.cpp
+++ b/host/src/performdocking.cpp
@@ -178,7 +178,8 @@ filled with clock() */
     status = cudaSetDevice(device);
     RTERROR(status, "cudaSetDevice failed");   
     cudaFree(NULL);   // Trick driver into creating context on current device
-    
+    status = cudaDeviceSetLimit(cudaLimitPrintfFifoSize, 200000000ull);
+    RTERROR(status, "cudaDeviceSetLimit failed");      
 
     auto const t1 = std::chrono::steady_clock::now();
     printf("CUDA Setup time %fs\n", elapsed_seconds(t0 ,t1));

--- a/host/src/performdocking.cpp
+++ b/host/src/performdocking.cpp
@@ -341,13 +341,42 @@ filled with clock() */
     status = cudaMemcpy(cData.pKerconst_conform, &KerConst_conform, sz_conform_const, cudaMemcpyHostToDevice);
     RTERROR(status, "cData.pKerconst_conform: failed to upload to GPU memory.\n");
 
+    // Allocate mem data
+    status = cudaMalloc((void**)&cData.pMem_angle_const, 1000 * sizeof(float));
+    RTERROR(status, "cData.pMem_angle_const: failed to allocate GPU memory.\n");
+    status = cudaMalloc((void**)&cData.pMem_dependence_on_theta_const, 1000 * sizeof(float));
+    RTERROR(status, "cData.pMem_dependence_on_theta_const: failed to allocate GPU memory.\n");
+    status = cudaMalloc((void**)&cData.pMem_dependence_on_rotangle_const, 1000 * sizeof(float));
+    RTERROR(status, "cData.pMem_dependence_on_rotangle_const: failed to allocate GPU memory.\n");
+    status = cudaMalloc((void**)&cData.pMem_rotbonds_const, 2*MAX_NUM_OF_ROTBONDS*sizeof(int));
+    RTERROR(status, "cData.pMem_rotbonds_const: failed to allocate GPU memory.\n");
+    status = cudaMalloc((void**)&cData.pMem_rotbonds_atoms_const, MAX_NUM_OF_ATOMS*MAX_NUM_OF_ROTBONDS*sizeof(int));
+    RTERROR(status, "cData.pMem_rotbonds_atoms_const: failed to allocate GPU memory.\n");
+    status = cudaMalloc((void**)&cData.pMem_num_rotating_atoms_per_rotbond_const, MAX_NUM_OF_ROTBONDS*sizeof(int));
+    RTERROR(status, "cData.pMem_num_rotiating_atoms_per_rotbond_const: failed to allocate GPU memory.\n");
+
+    // Upload mem data
+    cudaMemcpy(cData.pMem_angle_const, angle, 1000 * sizeof(float), cudaMemcpyHostToDevice);
+    RTERROR(status, "cData.pMem_angle_const: failed to upload to GPU memory.\n");
+    cudaMemcpy(cData.pMem_dependence_on_theta_const, dependence_on_theta, 1000 * sizeof(float), cudaMemcpyHostToDevice);
+    RTERROR(status, "cData.pMem_dependence_on_theta_const: failed to upload to GPU memory.\n");
+    cudaMemcpy(cData.pMem_dependence_on_rotangle_const, dependence_on_rotangle, 1000 * sizeof(float), cudaMemcpyHostToDevice);
+    RTERROR(status, "cData.pMem_dependence_on_rotangle_const: failed to upload to GPU memory.\n");       
+    cudaMemcpy(cData.pMem_rotbonds_const, KerConst_grads.rotbonds, 2*MAX_NUM_OF_ROTBONDS*sizeof(int), cudaMemcpyHostToDevice);
+    RTERROR(status, "cData.pMem_rotbonds_const: failed to upload to GPU memory.\n");
+    cudaMemcpy(cData.pMem_rotbonds_atoms_const, KerConst_grads.rotbonds_atoms, MAX_NUM_OF_ATOMS*MAX_NUM_OF_ROTBONDS*sizeof(int), cudaMemcpyHostToDevice);
+    RTERROR(status, "cData.pMem_rotbonds_atoms_const: failed to upload to GPU memory.\n");
+    cudaMemcpy(cData.pMem_num_rotating_atoms_per_rotbond_const, KerConst_grads.num_rotating_atoms_per_rotbond, MAX_NUM_OF_ROTBONDS*sizeof(int), cudaMemcpyHostToDevice);
+    RTERROR(status, "cData.pMem_num_rotating_atoms_per_rotbond_const failed to upload to GPU memory.\n"); 
+    
+/*    
     memcpy(cData.mem_angle_const, angle, 1000 * sizeof(float));
     memcpy(cData.mem_dependence_on_theta_const, dependence_on_theta, 1000 * sizeof(float));
     memcpy(cData.mem_dependence_on_rotangle_const, dependence_on_rotangle, 1000 * sizeof(float));        
     memcpy(cData.mem_rotbonds_const, KerConst_grads.rotbonds, 2*MAX_NUM_OF_ROTBONDS*sizeof(int));
     memcpy(cData.mem_rotbonds_atoms_const, KerConst_grads.rotbonds_atoms, MAX_NUM_OF_ATOMS*MAX_NUM_OF_ROTBONDS*sizeof(int));
     memcpy(cData.mem_num_rotating_atoms_per_rotbond_const, KerConst_grads.num_rotating_atoms_per_rotbond, MAX_NUM_OF_ROTBONDS*sizeof(int));
-
+*/
  	//allocating GPU memory for populations, floatgirds,
 	//energies, evaluation counters and random number generator states
 	size_floatgrids = 4 * (sizeof(float)) * (mygrid->num_of_atypes+2) * (mygrid->size_xyz[0]) * (mygrid->size_xyz[1]) * (mygrid->size_xyz[2]);    

--- a/host/src/performdocking.cpp
+++ b/host/src/performdocking.cpp
@@ -328,6 +328,18 @@ filled with clock() */
     status = cudaMalloc((void**)&cData.pKerconst_conform, sz_conform_const);
     RTERROR(status, "cData.pKerconst_conform: failed to allocate GPU memory.\n");  
     
+    // Upload kernel constant data
+    status = cudaMemcpy(cData.pKerconst_interintra, &KerConst_interintra, sz_interintra_const, cudaMemcpyHostToDevice);
+    RTERROR(status, "cData.pKerconst_interintra: failed to upload to GPU memory.\n");
+    status = cudaMemcpy(cData.pKerconst_intracontrib, &KerConst_intracontrib, sz_intracontrib_const, cudaMemcpyHostToDevice);
+    RTERROR(status, "cData.pKerconst_intracontrib: failed to upload to GPU memory.\n");
+    status = cudaMemcpy(cData.pKerconst_intra, &KerConst_intra, sz_intra_const, cudaMemcpyHostToDevice);
+    RTERROR(status, "cData.pKerconst_intra: failed to upload to GPU memory.\n");
+    status = cudaMemcpy(cData.pKerconst_rotlist, &KerConst_rotlist, sz_rotlist_const, cudaMemcpyHostToDevice);
+    RTERROR(status, "cData.pKerconst_rotlist: failed to upload to GPU memory.\n");
+    status = cudaMemcpy(cData.pKerconst_conform, &KerConst_conform, sz_conform_const, cudaMemcpyHostToDevice);
+    RTERROR(status, "cData.pKerconst_conform: failed to upload to GPU memory.\n");
+
     memcpy(cData.mem_angle_const, angle, 1000 * sizeof(float));
     memcpy(cData.mem_dependence_on_theta_const, dependence_on_theta, 1000 * sizeof(float));
     memcpy(cData.mem_dependence_on_rotangle_const, dependence_on_rotangle, 1000 * sizeof(float));        
@@ -380,8 +392,7 @@ filled with clock() */
     // Set CUDA constants
     cData.warpmask = 31;
     cData.warpbits = 5;
-    
-    
+
     // Upload data
     status = cudaMemcpy(pMem_fgrids, cpu_floatgrids, size_floatgrids, cudaMemcpyHostToDevice);
     RTERROR(status, "pMem_fgrids: failed to upload to GPU memory.\n"); 

--- a/host/src/performdocking.cpp
+++ b/host/src/performdocking.cpp
@@ -22,37 +22,27 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 */
 
+#include <chrono>
 
 
+// CUDA kernels
+void gpu_calc_initpop(uint32_t blocks, uint32_t threadsPerBlock, float* pConformations_current, float* pEnergies_current);
+void gpu_sum_evals(uint32_t blocks, uint32_t threadsPerBlock);
+void gpu_gen_and_eval_newpops(
+    uint32_t blocks,
+    uint32_t threadsPerBlock,
+    float* pMem_conformations_current,
+    float* pMem_energies_current,
+    float* pMem_conformations_next,
+    float* pMem_energies_next
+);
+void gpu_gradient_minAD(
+    uint32_t blocks,
+    uint32_t threads,
+    float* pMem_conformations_next,
+	float* pMem_energies_next
+);
 
-#ifndef _WIN32
-#define STRINGIZE2(s) #s
-#define STRINGIZE(s)	STRINGIZE2(s)
-#define KRNL_FILE STRINGIZE(KRNL_SOURCE)
-#define KRNL_FOLDER STRINGIZE(KRNL_DIRECTORY)
-#define KRNL_COMMON STRINGIZE(KCMN_DIRECTORY)
-#define KRNL1 STRINGIZE(K1)
-#define KRNL2 STRINGIZE(K2)
-#define KRNL3 STRINGIZE(K3)
-#define KRNL4 STRINGIZE(K4)
-#define KRNL5 STRINGIZE(K5)
-#define KRNL6 STRINGIZE(K6)
-#define KRNL7 STRINGIZE(K7)
-
-#else
-#define KRNL_FILE KRNL_SOURCE
-#define KRNL_FOLDER KRNL_DIRECTORY
-#define KRNL_COMMON KCMN_DIRECTORY
-#define KRNL1 K1
-#define KRNL2 K2
-#define KRNL3 K3
-#define KRNL4 K4
-#define KRNL5 K5
-#define KRNL6 K6
-#define KRNL7 K7
-#endif
-
-#define INC " -I " KRNL_FOLDER " -I " KRNL_COMMON
 
 #if defined (N1WI)
 	#define KNWI " -DN1WI "
@@ -62,6 +52,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 	#define KNWI " -DN4WI "
 #elif defined (N8WI)
 	#define KNWI " -DN8WI "
+#elif defined (N12WI)
+	#define KNWI " -DN12WI "
 #elif defined (N16WI)
 	#define KNWI " -DN16WI "
 #elif defined (N32WI)
@@ -105,8 +97,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define OPT_PROG INC KNWI REP KGDB
 
 #include "performdocking.h"
-#include "stringify.h"
 #include "correct_grad_axisangle.h"
+#include "GpuData.h"
+
+template <typename Clock, typename Duration1, typename Duration2>
+double elapsed_seconds(std::chrono::time_point<Clock, Duration1> start,
+                       std::chrono::time_point<Clock, Duration2> end)
+{
+  using FloatingPointSeconds = std::chrono::duration<double, std::ratio<1>>;
+  return std::chrono::duration_cast<FloatingPointSeconds>(end - start).count();
+}
+
+
 
 inline float average(float* average_sd2_N)
 {
@@ -124,14 +126,14 @@ inline float stddev(float* average_sd2_N)
 	return sqrt(sq)/average_sd2_N[2];
 }
 
-int docking_with_gpu(const Gridinfo*  	 	mygrid,
-	         /*const*/ float*      		cpu_floatgrids,
-                           Dockpars*   		mypars,
-		     const Liganddata* 		myligand_init,
-		     const Liganddata* 		myxrayligand,
-		     const int*        		argc,
-		           char**      		argv,
-		           clock_t     		clock_start_program)
+int docking_with_gpu(   const Gridinfo*  	mygrid,
+                        float*      		cpu_floatgrids,
+                        Dockpars*   		mypars,
+                        const Liganddata*   myligand_init,
+                        const Liganddata* 	myxrayligand,
+                        const int*        	argc,
+                        char**      		argv,
+                        clock_t     		clock_start_program)
 /* The function performs the docking algorithm and generates the corresponding result files.
 parameter mygrid:
 		describes the grid
@@ -153,97 +155,32 @@ parameters argc and argv:
 		contains the state of the clock tick counter at the beginning of the program
 filled with clock() */
 {
-// =======================================================================
-// OpenCL Host Setup
-// =======================================================================
-	cl_platform_id*  platform_id;
-	cl_device_id*    device_ids;
-	cl_device_id     device_id;
-	cl_context       context;
-	cl_command_queue command_queue;
-	cl_program       program;
+    auto const t0 = std::chrono::steady_clock::now();
 
-#ifdef _WIN32
-	const char *filename = KRNL_FILE;
-	printf("\n%-40s %-40s\n", "Kernel source file: ", filename);  fflush(stdout);
-#else
-	printf("\n%-40s %-40s\n", "Kernel source used for development: ", "./device/calcenergy.cl");  fflush(stdout);
-	printf(  "%-40s %-40s\n", "Kernel string used for building: ",    "./host/inc/stringify.h");  fflush(stdout);
-#endif
+    // Initialize CUDA
+    int device                                      = -1;
+    int gpuCount                                    = 0;
+    cudaError_t status;
+    cudaDeviceProp deviceProp;
+    status = cudaGetDeviceCount(&gpuCount);
+    RTERROR(status, "cudaGetDeviceCount failed");
+    if (gpuCount == 0)
+    {
+        printf("No CUDA-capable devices found, exiting.\n");
+        cudaDeviceReset();
+        exit(-1);
+    }
+    else
+    {
+        // Select GPU with most memory available
+        device = 1; // HACK to not use display GPU for now
+    }
+    cudaFree(NULL);   // Trick driver into creating context on current device
+    
 
-	const char* options_program = OPT_PROG;
-	printf("%-40s %-40s\n", "Kernel compilation flags: ", options_program); fflush(stdout);
+    auto const t1 = std::chrono::steady_clock::now();
+    printf("CUDA Setup time %fs\n", elapsed_seconds(t0 ,t1));
 
-	cl_kernel kernel1; const char *name_k1 = KRNL1;
-	size_t kernel1_gxsize, kernel1_lxsize;
-
-	cl_kernel kernel2; const char *name_k2 = KRNL2;
-	size_t kernel2_gxsize, kernel2_lxsize;
-
-	cl_kernel kernel3; const char *name_k3 = KRNL3;
-	size_t kernel3_gxsize, kernel3_lxsize;
-
-	cl_kernel kernel4; const char *name_k4 = KRNL4;
-	size_t kernel4_gxsize, kernel4_lxsize;
-
-	cl_kernel kernel5; const char *name_k5 = KRNL5;
-	size_t kernel5_gxsize, kernel5_lxsize;
-
-	cl_kernel kernel6; const char *name_k6 = KRNL6;
-	size_t kernel6_gxsize, kernel6_lxsize;
-
-	cl_kernel kernel7; const char *name_k7 = KRNL7;
-	size_t kernel7_gxsize, kernel7_lxsize;
-
-	cl_uint platformCount;
-	cl_uint deviceCount;
-
-	// Times
-	cl_ulong time_start_kernel;
-	cl_ulong time_end_kernel;
-
-	// Get all available platforms
-	if (getPlatforms(&platform_id,&platformCount) != 0) return 1;
-
-	// Get all devices of first platform
-	if (getDevices(platform_id[0],platformCount,&device_ids,&deviceCount) != 0) return 1;
-	if (mypars->devnum>=deviceCount)
-	{
-		printf("Warning: user specified OpenCL device number does not exist, using first device.\n");
-		mypars->devnum=0;
-	}
-	device_id=device_ids[mypars->devnum];
-
-	// Create context from first platform
-	if (createContext(platform_id[0],1,&device_id,&context) != 0) return 1;
-
-	// Create command queue for first device
-	if (createCommandQueue(context,device_id,&command_queue) != 0) return 1;
-
-	// Create program from source 
-#ifdef _WIN32
-	if (ImportSource(filename, name_k1, &device_id, context, options_program, &kernel1) != 0) return 1;
-	if (ImportSource(filename, name_k2, &device_id, context, options_program, &kernel2) != 0) return 1;
-	if (ImportSource(filename, name_k3, &device_id, context, options_program, &kernel3) != 0) return 1;
-	if (ImportSource(filename, name_k4, &device_id, context, options_program, &kernel4) != 0) return 1;
-	if (ImportSource(filename, name_k5, &device_id, context, options_program, &kernel5) != 0) return 1;
-	if (ImportSource(filename, name_k6, &device_id, context, options_program, &kernel6) != 0) return 1;
-	if (ImportSource(filename, name_k7, &device_id, context, options_program, &kernel7) != 0) return 1;
-#else
-	if (ImportSourceToProgram(calcenergy_ocl, &device_id, context, &program, options_program) != 0) return 1;
-#endif
-
-	// Create kernels
-	if (createKernel(&device_id, &program, name_k1, &kernel1) != 0) return 1;
-	if (createKernel(&device_id, &program, name_k2, &kernel2) != 0) return 1;
-	if (createKernel(&device_id, &program, name_k3, &kernel3) != 0) return 1;
-	if (createKernel(&device_id, &program, name_k4, &kernel4) != 0) return 1;
-	if (createKernel(&device_id, &program, name_k5, &kernel5) != 0) return 1;
-	if (createKernel(&device_id, &program, name_k6, &kernel6) != 0) return 1;
-	if (createKernel(&device_id, &program, name_k7, &kernel7) != 0) return 1;
-
-// End of OpenCL Host Setup
-// =======================================================================
 
 	Liganddata myligand_reference;
 
@@ -255,7 +192,6 @@ filled with clock() */
 	int* cpu_evals_of_runs;
 	float* cpu_ref_ori_angles;
 
-	Dockparameters dockpars;
 	size_t size_floatgrids;
 	size_t size_populations;
 	size_t size_energies;
@@ -338,14 +274,15 @@ filled with clock() */
 	if (prepare_const_fields_for_gpu(&myligand_reference, mypars, cpu_ref_ori_angles, &KerConst) == 1)
 		return 1;
 */
-
-	kernelconstant_interintra	KerConst_interintra;
-	kernelconstant_intracontrib	KerConst_intracontrib;
-	kernelconstant_intra		KerConst_intra;
-	kernelconstant_rotlist		KerConst_rotlist;
-	kernelconstant_conform		KerConst_conform;
-	kernelconstant_grads		KerConst_grads;
-
+    GpuData cData;
+    kernelconstant_interintra 	    KerConst_interintra;
+	kernelconstant_intracontrib 	KerConst_intracontrib;
+	kernelconstant_intra 		    KerConst_intra;
+	kernelconstant_rotlist 	        KerConst_rotlist;
+    kernelconstant_conform 	        KerConst_conform;
+	kernelconstant_grads            KerConst_grads;    
+    
+    
 	if (prepare_const_fields_for_gpu(&myligand_reference, mypars, cpu_ref_ori_angles, 
 					 &KerConst_interintra, 
 					 &KerConst_intracontrib, 
@@ -356,40 +293,10 @@ filled with clock() */
 		return 1;
 	}
 
-	// Constant data holding struct data
-	// Created because structs containing array
-	// are not supported as OpenCL kernel args
-/*
-  	cl_mem mem_atom_charges_const;
-	cl_mem mem_atom_types_const;
-  	cl_mem mem_intraE_contributors_const;
-  	cl_mem mem_reqm_const;
-  	cl_mem mem_reqm_hbond_const;
-  	cl_mem mem_atom1_types_reqm_const;
-  	cl_mem mem_atom2_types_reqm_const;
-  	cl_mem mem_VWpars_AC_const;
-  	cl_mem mem_VWpars_BD_const;
-  	cl_mem mem_dspars_S_const;
-  	cl_mem mem_dspars_V_const;
-  	cl_mem mem_rotlist_const;
-  	cl_mem mem_ref_coords_x_const;
-  	cl_mem mem_ref_coords_y_const;
-  	cl_mem mem_ref_coords_z_const;
-  	cl_mem mem_rotbonds_moving_vectors_const;
-  	cl_mem mem_rotbonds_unit_vectors_const;
-  	cl_mem mem_ref_orientation_quats_const;
-*/
-
-	cl_mem mem_interintra_const;
-	cl_mem mem_intracontrib_const;
-	cl_mem mem_intra_const;
-	cl_mem mem_rotlist_const;
-	cl_mem mem_conform_const;
-
 	size_t sz_interintra_const	= MAX_NUM_OF_ATOMS*sizeof(float) + 
-					  MAX_NUM_OF_ATOMS*sizeof(char);
+					  MAX_NUM_OF_ATOMS*sizeof(uint32_t);
 
-	size_t sz_intracontrib_const	= 3*MAX_INTRAE_CONTRIBUTORS*sizeof(char);
+	size_t sz_intracontrib_const	= 3*MAX_INTRAE_CONTRIBUTORS*sizeof(uint32_t);
 
 	size_t sz_intra_const		= ATYPE_NUM*sizeof(float) + 
 					  ATYPE_NUM*sizeof(float) + 
@@ -406,190 +313,136 @@ filled with clock() */
 					  3*MAX_NUM_OF_ROTBONDS*sizeof(float) + 
 					  3*MAX_NUM_OF_ROTBONDS*sizeof(float) + 
 					  4*MAX_NUM_OF_RUNS*sizeof(float);
+                      
+    size_t sz_grads_const       = 
 
-  	cl_mem mem_rotbonds_const;
-  	cl_mem mem_rotbonds_atoms_const;
-  	cl_mem mem_num_rotating_atoms_per_rotbond_const;
-
-	// Constant data for correcting axisangle gradients
-	cl_mem mem_angle_const;
-	cl_mem mem_dependence_on_theta_const;
-	cl_mem mem_dependence_on_rotangle_const;
-
-	// These constants are allocated in global memory since
-	// there is a limited number of constants that can be passed
-	// as arguments to kernel
-/*
-	mallocBufferObject(context,CL_MEM_READ_ONLY,MAX_NUM_OF_ATOMS*sizeof(float),                         &mem_atom_charges_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,MAX_NUM_OF_ATOMS*sizeof(char),                          &mem_atom_types_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,3*MAX_INTRAE_CONTRIBUTORS*sizeof(char),                 &mem_intraE_contributors_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,ATYPE_NUM*sizeof(float),				    &mem_reqm_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,ATYPE_NUM*sizeof(float),				    &mem_reqm_hbond_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,ATYPE_NUM*sizeof(unsigned int),			    &mem_atom1_types_reqm_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,ATYPE_NUM*sizeof(unsigned int),                         &mem_atom2_types_reqm_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,MAX_NUM_OF_ATYPES*MAX_NUM_OF_ATYPES*sizeof(float),      &mem_VWpars_AC_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,MAX_NUM_OF_ATYPES*MAX_NUM_OF_ATYPES*sizeof(float),      &mem_VWpars_BD_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,MAX_NUM_OF_ATYPES*sizeof(float),                        &mem_dspars_S_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,MAX_NUM_OF_ATYPES*sizeof(float),                        &mem_dspars_V_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,MAX_NUM_OF_ROTATIONS*sizeof(int),                       &mem_rotlist_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,MAX_NUM_OF_ATOMS*sizeof(float),                         &mem_ref_coords_x_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,MAX_NUM_OF_ATOMS*sizeof(float),                         &mem_ref_coords_y_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,MAX_NUM_OF_ATOMS*sizeof(float),                         &mem_ref_coords_z_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,3*MAX_NUM_OF_ROTBONDS*sizeof(float),                    &mem_rotbonds_moving_vectors_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,3*MAX_NUM_OF_ROTBONDS*sizeof(float),                    &mem_rotbonds_unit_vectors_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,4*MAX_NUM_OF_RUNS*sizeof(float),                        &mem_ref_orientation_quats_const);
-*/
-
-	mallocBufferObject(context,CL_MEM_READ_ONLY,sz_interintra_const,	&mem_interintra_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,sz_intracontrib_const,   	&mem_intracontrib_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,sz_intra_const,             &mem_intra_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,sz_rotlist_const,           &mem_rotlist_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,sz_conform_const,           &mem_conform_const);
-
-	mallocBufferObject(context,CL_MEM_READ_ONLY,2*MAX_NUM_OF_ROTBONDS*sizeof(int),                      &mem_rotbonds_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,MAX_NUM_OF_ATOMS*MAX_NUM_OF_ROTBONDS*sizeof(int),       &mem_rotbonds_atoms_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,MAX_NUM_OF_ROTBONDS*sizeof(int),      		    &mem_num_rotating_atoms_per_rotbond_const);
-
-	mallocBufferObject(context,CL_MEM_READ_ONLY,1000*sizeof(float),&mem_angle_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,1000*sizeof(float),&mem_dependence_on_theta_const);
-	mallocBufferObject(context,CL_MEM_READ_ONLY,1000*sizeof(float),&mem_dependence_on_rotangle_const);
-   	
-/*
-	memcopyBufferObjectToDevice(command_queue,mem_atom_charges_const,			false,  &KerConst.atom_charges_const,           MAX_NUM_OF_ATOMS*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_atom_types_const,           		false,	&KerConst.atom_types_const,             MAX_NUM_OF_ATOMS*sizeof(char));
-	memcopyBufferObjectToDevice(command_queue,mem_intraE_contributors_const,  		false,  &KerConst.intraE_contributors_const,    3*MAX_INTRAE_CONTRIBUTORS*sizeof(char));
-	memcopyBufferObjectToDevice(command_queue,mem_reqm_const,         			false,  &KerConst.reqm_const,           	ATYPE_NUM*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_reqm_hbond_const,         		false,	&KerConst.reqm_hbond_const,           	ATYPE_NUM*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_atom1_types_reqm_const,         		false,  &KerConst.atom1_types_reqm_const,       ATYPE_NUM*sizeof(unsigned int));
-	memcopyBufferObjectToDevice(command_queue,mem_atom2_types_reqm_const,         		false,	&KerConst.atom2_types_reqm_const,       ATYPE_NUM*sizeof(unsigned int));
-	memcopyBufferObjectToDevice(command_queue,mem_VWpars_AC_const,            		false,	&KerConst.VWpars_AC_const,              MAX_NUM_OF_ATYPES*MAX_NUM_OF_ATYPES*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_VWpars_BD_const,            		false,	&KerConst.VWpars_BD_const,              MAX_NUM_OF_ATYPES*MAX_NUM_OF_ATYPES*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_dspars_S_const,             		false,	&KerConst.dspars_S_const,               MAX_NUM_OF_ATYPES*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_dspars_V_const,             		false,	&KerConst.dspars_V_const,               MAX_NUM_OF_ATYPES*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_rotlist_const,              		false,	&KerConst.rotlist_const,                MAX_NUM_OF_ROTATIONS*sizeof(int));
-	memcopyBufferObjectToDevice(command_queue,mem_ref_coords_x_const,         		false,	&KerConst.ref_coords_x_const,           MAX_NUM_OF_ATOMS*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_ref_coords_y_const,         		false,	&KerConst.ref_coords_y_const,           MAX_NUM_OF_ATOMS*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_ref_coords_z_const,         		false,	&KerConst.ref_coords_z_const,           MAX_NUM_OF_ATOMS*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_rotbonds_moving_vectors_const,		false,	&KerConst.rotbonds_moving_vectors_const,3*MAX_NUM_OF_ROTBONDS*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_rotbonds_unit_vectors_const,  		false,	&KerConst.rotbonds_unit_vectors_const,  3*MAX_NUM_OF_ROTBONDS*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_ref_orientation_quats_const, 		false,	&KerConst.ref_orientation_quats_const,  4*MAX_NUM_OF_RUNS*sizeof(float));
-*/
-	
-	memcopyBufferObjectToDevice(command_queue,mem_interintra_const,		false,	&KerConst_interintra,	sz_interintra_const);
-	memcopyBufferObjectToDevice(command_queue,mem_intracontrib_const,      	false,	&KerConst_intracontrib, sz_intracontrib_const);
-	memcopyBufferObjectToDevice(command_queue,mem_intra_const,       	false,	&KerConst_intra,       	sz_intra_const);
-	memcopyBufferObjectToDevice(command_queue,mem_rotlist_const,     	false,	&KerConst_rotlist,     	sz_rotlist_const);
-	memcopyBufferObjectToDevice(command_queue,mem_conform_const,     	false,	&KerConst_conform,     	sz_conform_const);
-
-	memcopyBufferObjectToDevice(command_queue,mem_rotbonds_const,  	      			false,	&KerConst_grads.rotbonds,  			2*MAX_NUM_OF_ROTBONDS*sizeof(int));
-	memcopyBufferObjectToDevice(command_queue,mem_rotbonds_atoms_const,  	      		false,	&KerConst_grads.rotbonds_atoms,  		MAX_NUM_OF_ATOMS*MAX_NUM_OF_ROTBONDS*sizeof(int));
-	memcopyBufferObjectToDevice(command_queue,mem_num_rotating_atoms_per_rotbond_const, 	false,	&KerConst_grads.num_rotating_atoms_per_rotbond, MAX_NUM_OF_ROTBONDS*sizeof(int));
-
-  	memcopyBufferObjectToDevice(command_queue,mem_angle_const,				false,  &angle,           		1000*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_dependence_on_theta_const,		false,  &dependence_on_theta,           1000*sizeof(float));
-	memcopyBufferObjectToDevice(command_queue,mem_dependence_on_rotangle_const,		false,  &dependence_on_rotangle,        1000*sizeof(float));
-	// ----------------------------------------------------------------------
+    // Allocate kernel constant GPU memory
+    status = cudaMalloc((void**)&cData.pKerconst_interintra, sz_interintra_const);
+    RTERROR(status, "cData.pKerconst_interintra: failed to allocate GPU memory.\n");    
+    status = cudaMalloc((void**)&cData.pKerconst_intracontrib, sz_intracontrib_const);
+    RTERROR(status, "cData.pKerconst_intracontrib: failed to allocate GPU memory.\n");
+    status = cudaMalloc((void**)&cData.pKerconst_intra, sz_intra_const);
+    RTERROR(status, "cData.pKerconst_intra: failed to allocate GPU memory.\n");
+    status = cudaMalloc((void**)&cData.pKerconst_rotlist, sz_rotlist_const);
+    RTERROR(status, "cData.pKerconst_rotlist: failed to allocate GPU memory.\n");                      
+    status = cudaMalloc((void**)&cData.pKerconst_conform, sz_conform_const);
+    RTERROR(status, "cData.pKerconst_conform: failed to allocate GPU memory.\n");  
+    
+    memcpy(cData.mem_angle_const, angle, 1000 * sizeof(float));
+    memcpy(cData.mem_dependence_on_theta_const, dependence_on_theta, 1000 * sizeof(float));
+    memcpy(cData.mem_dependence_on_rotangle_const, dependence_on_rotangle, 1000 * sizeof(float));        
+    memcpy(cData.mem_rotbonds_const, KerConst_grads.rotbonds, 2*MAX_NUM_OF_ROTBONDS*sizeof(int));
+    memcpy(cData.mem_rotbonds_atoms_const, KerConst_grads.rotbonds_atoms, MAX_NUM_OF_ATOMS*MAX_NUM_OF_ROTBONDS*sizeof(int));
+    memcpy(cData.mem_num_rotating_atoms_per_rotbond_const, KerConst_grads.num_rotating_atoms_per_rotbond, MAX_NUM_OF_ROTBONDS*sizeof(int));
 
  	//allocating GPU memory for populations, floatgirds,
 	//energies, evaluation counters and random number generator states
-	size_floatgrids = 4 * (sizeof(float)) * (mygrid->num_of_atypes+2) * (mygrid->size_xyz[0]) * (mygrid->size_xyz[1]) * (mygrid->size_xyz[2]);
-
-	cl_mem mem_dockpars_fgrids;
-	cl_mem mem_dockpars_conformations_current;
-	cl_mem mem_dockpars_energies_current;
-	cl_mem mem_dockpars_conformations_next;
-	cl_mem mem_dockpars_energies_next;
-	cl_mem mem_dockpars_evals_of_new_entities;
-	cl_mem mem_gpu_evals_of_runs;
-	cl_mem mem_dockpars_prng_states;
-
-	mallocBufferObject(context,CL_MEM_READ_ONLY,size_floatgrids,         			&mem_dockpars_fgrids);
-	mallocBufferObject(context,CL_MEM_READ_WRITE,size_populations,        			&mem_dockpars_conformations_current);
-	mallocBufferObject(context,CL_MEM_READ_WRITE,size_energies,           			&mem_dockpars_energies_current);
-	mallocBufferObject(context,CL_MEM_READ_WRITE,size_populations,        			&mem_dockpars_conformations_next);
-	mallocBufferObject(context,CL_MEM_READ_WRITE,size_energies,    	      			&mem_dockpars_energies_next);
-	mallocBufferObject(context,CL_MEM_READ_WRITE,mypars->pop_size*mypars->num_of_runs*sizeof(int), 	&mem_dockpars_evals_of_new_entities);
-
-	// -------- Replacing with memory maps! ------------
-#if defined (MAPPED_COPY)
-	mallocBufferObject(context,CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR ,size_evals_of_runs,	  			&mem_gpu_evals_of_runs);
-#else
-	mallocBufferObject(context,CL_MEM_READ_WRITE,size_evals_of_runs,	  			&mem_gpu_evals_of_runs);
-#endif
-	// -------- Replacing with memory maps! ------------
-
-	mallocBufferObject(context,CL_MEM_READ_WRITE,size_prng_seeds,  	      				&mem_dockpars_prng_states);
-
-	memcopyBufferObjectToDevice(command_queue,mem_dockpars_fgrids,                	false, cpu_floatgrids,  	size_floatgrids);
- 	memcopyBufferObjectToDevice(command_queue,mem_dockpars_conformations_current, 	false, cpu_init_populations, 	size_populations);
-	memcopyBufferObjectToDevice(command_queue,mem_gpu_evals_of_runs, 		false, cpu_evals_of_runs, 	size_evals_of_runs);
-	memcopyBufferObjectToDevice(command_queue,mem_dockpars_prng_states,     	false, cpu_prng_seeds,      	size_prng_seeds);
+	size_floatgrids = 4 * (sizeof(float)) * (mygrid->num_of_atypes+2) * (mygrid->size_xyz[0]) * (mygrid->size_xyz[1]) * (mygrid->size_xyz[2]);    
+    float*      pMem_fgrids;
+    float*      pMem_conformations1;
+    float*      pMem_conformations2;
+    float*      pMem_energies1;
+    float*      pMem_energies2;
+    int*        pMem_evals_of_new_entities;
+    int*        pMem_gpu_evals_of_runs;
+    uint32_t*   pMem_prng_states;
+    
+    // Allocate CUDA memory Buffers
+    status = cudaMalloc((void**)&pMem_fgrids, size_floatgrids);
+    RTERROR(status, "pMem_fgrids: failed to allocate GPU memory.\n");
+    status = cudaMalloc((void**)&pMem_conformations1, size_populations);
+    RTERROR(status, "pMem_conformations1: failed to allocate GPU memory.\n");   
+    status = cudaMalloc((void**)&pMem_conformations2, size_populations);
+    RTERROR(status, "pMem_conformations2: failed to allocate GPU memory.\n");     
+    status = cudaMalloc((void**)&pMem_energies1, size_energies);
+    RTERROR(status, "pMem_energies1: failed to allocate GPU memory.\n");    
+    status = cudaMalloc((void**)&pMem_energies2, size_energies);
+    RTERROR(status, "pMem_energies2: failed to allocate GPU memory.\n");  
+    status = cudaMalloc((void**)&pMem_evals_of_new_entities, mypars->pop_size*mypars->num_of_runs*sizeof(int));
+    RTERROR(status, "pMem_evals_of_new_Entities: failed to allocate GPU memory.\n");      
+    status = cudaMallocManaged((void**)&pMem_gpu_evals_of_runs, size_evals_of_runs, cudaMemAttachGlobal);
+    RTERROR(status, "pMem_gpu_evals_of_runs: failed to allocate GPU memory.\n");   
+    status = cudaMalloc((void**)&pMem_prng_states, size_prng_seeds);
+    RTERROR(status, "pMem_prng_states: failed to allocate GPU memory.\n");    
+    
+    // Flippable pointers
+    float* pMem_conformations_current = pMem_conformations1;
+    float* pMem_conformations_next = pMem_conformations2;
+    float* pMem_energies_current = pMem_energies1;
+    float* pMem_energies_next = pMem_energies2;
+    
+    // Set constant pointers
+    cData.pMem_fgrids = pMem_fgrids;
+    cData.pMem_evals_of_new_entities = pMem_evals_of_new_entities;
+    cData.pMem_gpu_evals_of_runs = pMem_gpu_evals_of_runs;
+    cData.pMem_prng_states = pMem_prng_states;
+    
+    // Set CUDA constants
+    cData.warpmask = 31;
+    cData.warpbits = 5;
+    
+    
+    // Upload data
+    status = cudaMemcpy(pMem_fgrids, cpu_floatgrids, size_floatgrids, cudaMemcpyHostToDevice);
+    RTERROR(status, "pMem_fgrids: failed to upload to GPU memory.\n"); 
+    status = cudaMemcpy(pMem_conformations_current, cpu_init_populations, size_populations, cudaMemcpyHostToDevice);
+    RTERROR(status, "pMem_conformations_current: failed to upload to GPU memory.\n"); 
+    status = cudaMemcpy(pMem_gpu_evals_of_runs, cpu_evals_of_runs, size_evals_of_runs, cudaMemcpyHostToDevice);
+    RTERROR(status, "pMem_gpu_evals_of_runs: failed to upload to GPU memory.\n"); 
+    status = cudaMemcpy(pMem_prng_states, cpu_prng_seeds, size_prng_seeds, cudaMemcpyHostToDevice);
+    RTERROR(status, "pMem_prng_states: failed to upload to GPU memory.\n");
 
 	//preparing parameter struct
-	dockpars.num_of_atoms  = ((char)  myligand_reference.num_of_atoms);
-	dockpars.num_of_atypes = ((char)  myligand_reference.num_of_atypes);
-	dockpars.num_of_intraE_contributors = ((int) myligand_reference.num_of_intraE_contributors);
-	dockpars.gridsize_x    = ((char)  mygrid->size_xyz[0]);
-	dockpars.gridsize_y    = ((char)  mygrid->size_xyz[1]);
-	dockpars.gridsize_z    = ((char)  mygrid->size_xyz[2]);
-	dockpars.grid_spacing  = ((float) mygrid->spacing);
-	dockpars.rotbondlist_length = ((int) NUM_OF_THREADS_PER_BLOCK*(myligand_reference.num_of_rotcyc));
-	dockpars.coeff_elec    = ((float) mypars->coeffs.scaled_AD4_coeff_elec);
-	dockpars.coeff_desolv  = ((float) mypars->coeffs.AD4_coeff_desolv);
-	dockpars.pop_size      = mypars->pop_size;
-	dockpars.num_of_genes  = myligand_reference.num_of_rotbonds + 6;
+	cData.dockpars.num_of_atoms                 = myligand_reference.num_of_atoms;
+	cData.dockpars.num_of_atypes                = myligand_reference.num_of_atypes;
+	cData.dockpars.num_of_intraE_contributors   = ((int) myligand_reference.num_of_intraE_contributors);
+	cData.dockpars.gridsize_x                   = mygrid->size_xyz[0];
+	cData.dockpars.gridsize_y                   = mygrid->size_xyz[1];
+	cData.dockpars.gridsize_z                   = mygrid->size_xyz[2];
+    cData.dockpars.gridsize_x_times_y           = cData.dockpars.gridsize_x * cData.dockpars.gridsize_y; 
+    cData.dockpars.gridsize_x_times_y_times_z   = cData.dockpars.gridsize_x * cData.dockpars.gridsize_y * cData.dockpars.gridsize_z;     
+	cData.dockpars.grid_spacing                 = ((float) mygrid->spacing);
+	cData.dockpars.rotbondlist_length           = ((int) NUM_OF_THREADS_PER_BLOCK*(myligand_reference.num_of_rotcyc));
+	cData.dockpars.coeff_elec                   = ((float) mypars->coeffs.scaled_AD4_coeff_elec);
+	cData.dockpars.coeff_desolv                 = ((float) mypars->coeffs.AD4_coeff_desolv);
+	cData.dockpars.pop_size                     = mypars->pop_size;
+	cData.dockpars.num_of_genes                 = myligand_reference.num_of_rotbonds + 6;
 	// Notice: dockpars.tournament_rate, dockpars.crossover_rate, dockpars.mutation_rate
 	// were scaled down to [0,1] in host to reduce number of operations in device
-	dockpars.tournament_rate = mypars->tournament_rate/100.0f; 
-	dockpars.crossover_rate  = mypars->crossover_rate/100.0f;
-	dockpars.mutation_rate   = mypars->mutation_rate/100.f;
-	dockpars.abs_max_dang    = mypars->abs_max_dang;
-	dockpars.abs_max_dmov    = mypars->abs_max_dmov;
-	dockpars.qasp 		 = mypars->qasp;
-	dockpars.smooth 	 = mypars->smooth;
-	unsigned int g2 = dockpars.gridsize_x * dockpars.gridsize_y;
-	unsigned int g3 = dockpars.gridsize_x * dockpars.gridsize_y * dockpars.gridsize_z;
+	cData.dockpars.tournament_rate              = mypars->tournament_rate/100.0f; 
+	cData.dockpars.crossover_rate               = mypars->crossover_rate/100.0f;
+	cData.dockpars.mutation_rate                = mypars->mutation_rate/100.f;
+	cData.dockpars.abs_max_dang                 = mypars->abs_max_dang;
+	cData.dockpars.abs_max_dmov                 = mypars->abs_max_dmov;
+	cData.dockpars.qasp 		                = mypars->qasp;
+	cData.dockpars.smooth 	                    = mypars->smooth;
+	unsigned int g2                             = cData.dockpars.gridsize_x * cData.dockpars.gridsize_y;
+	unsigned int g3                             = cData.dockpars.gridsize_x * cData.dockpars.gridsize_y * cData.dockpars.gridsize_z;
 
-	dockpars.lsearch_rate    = mypars->lsearch_rate;
+	cData.dockpars.lsearch_rate                 = mypars->lsearch_rate;
 
-	if (dockpars.lsearch_rate != 0.0f) 
+	if (cData.dockpars.lsearch_rate != 0.0f) 
 	{
-		dockpars.num_of_lsentities = (unsigned int) (mypars->lsearch_rate/100.0*mypars->pop_size + 0.5);
-		dockpars.rho_lower_bound   = mypars->rho_lower_bound;
-		dockpars.base_dmov_mul_sqrt3 = mypars->base_dmov_mul_sqrt3;
-		dockpars.base_dang_mul_sqrt3 = mypars->base_dang_mul_sqrt3;
-		dockpars.cons_limit        = (unsigned int) mypars->cons_limit;
-		dockpars.max_num_of_iters  = (unsigned int) mypars->max_num_of_iters;
+		cData.dockpars.num_of_lsentities        = (unsigned int) (mypars->lsearch_rate/100.0*mypars->pop_size + 0.5);
+		cData.dockpars.rho_lower_bound          = mypars->rho_lower_bound;
+		cData.dockpars.base_dmov_mul_sqrt3      = mypars->base_dmov_mul_sqrt3;
+		cData.dockpars.base_dang_mul_sqrt3      = mypars->base_dang_mul_sqrt3;
+		cData.dockpars.cons_limit               = (unsigned int) mypars->cons_limit;
+		cData.dockpars.max_num_of_iters         = (unsigned int) mypars->max_num_of_iters;
 
 		// The number of entities that undergo Solis-Wets minimization,
-		blocksPerGridForEachLSEntity = dockpars.num_of_lsentities*mypars->num_of_runs;
+		blocksPerGridForEachLSEntity = cData.dockpars.num_of_lsentities * mypars->num_of_runs;
 
 		// The number of entities that undergo any gradient-based minimization,
 		// by default, it is the same as the number of entities that undergo the Solis-Wets minimizer
-		blocksPerGridForEachGradMinimizerEntity = dockpars.num_of_lsentities*mypars->num_of_runs;
+		blocksPerGridForEachGradMinimizerEntity = cData.dockpars.num_of_lsentities * mypars->num_of_runs;
 
 		// Enable only for debugging.
 		// Only one entity per reach run, undergoes gradient minimization
 		//blocksPerGridForEachGradMinimizerEntity = mypars->num_of_runs;
 	}
 	
-	if(mypars->use_heuristics && !mypars->nev_provided){
-		printf("Using heuristics: ");
-		char newmethod[128];
-		if(myligand_init->num_of_rotbonds<8){ // use Solis-Wets
-			strcpy(newmethod,"sw");
-//			mypars->num_of_energy_evals = (unsigned long)ceil(1000 * pow(2.0,1.3 * myligand_init->num_of_rotbonds + 3.5));
-			mypars->num_of_energy_evals = (unsigned long)ceil(1000 * pow(2.0,1.3 * myligand_init->num_of_rotbonds + 4.0));
-			printf("-lsmet sw -nev %u\n",mypars->num_of_energy_evals);
-		} else{ // use ADAdelta
-			strcpy(newmethod,"ad");
-			mypars->num_of_energy_evals = (unsigned long)ceil(1000 * pow(2.0,0.4 * myligand_init->num_of_rotbonds + 7.0));
-			printf("-lsmet ad -nev %u\n",mypars->num_of_energy_evals);
-		}
-		strcpy(mypars->ls_method,newmethod);
-	}
-	
-	printf("Local-search chosen method is: %s\n", (dockpars.lsearch_rate == 0.0f)? "GA" :
+	printf("Local-search chosen method is: %s\n", (cData.dockpars.lsearch_rate == 0.0f)? "GA" :
 						      (
 						      (strcmp(mypars->ls_method, "sw")   == 0)?"Solis-Wets (sw)":
 						      (strcmp(mypars->ls_method, "sd")   == 0)?"Steepest-Descent (sd)": 
@@ -608,7 +461,7 @@ filled with clock() */
 #ifndef DOCK_DEBUG
 	if (mypars->autostop)
 	{
-		printf("\nExecuting docking runs, stopping automatically after either reaching %.2f kcal/mol standard deviation\nof the best molecules, %u generations, or %u evaluations, whichever comes first:\n\n",mypars->stopstd,mypars->num_of_generations,mypars->num_of_energy_evals);
+		printf("\nExecuting docking runs, stopping automatically after either reaching %.2f kcal/mol standard deviation\nof the best molecules, %lu generations, or %lu evaluations, whichever comes first:\n\n",mypars->stopstd,mypars->num_of_generations,mypars->num_of_energy_evals);
 		printf("Generations |  Evaluations |     Threshold    |  Average energy of best 10%%  | Samples |    Best energy\n");
 		printf("------------+--------------+------------------+------------------------------+---------+-------------------\n");
 	}
@@ -629,7 +482,7 @@ filled with clock() */
 #endif
 
 	/*
-	// Addded for printing intracontributor_pairs (autodockdevpy)
+	// Added for printing intracontributor_pairs (autodockdevpy)
 	for (unsigned int intrapair_cnt=0; 
 			  intrapair_cnt<dockpars.num_of_intraE_contributors;
 			  intrapair_cnt++) {
@@ -644,130 +497,37 @@ filled with clock() */
 	*/
 
 	// Kernel1
-	setKernelArg(kernel1,0, sizeof(dockpars.num_of_atoms),                  &dockpars.num_of_atoms);
-	setKernelArg(kernel1,1, sizeof(dockpars.num_of_atypes),                 &dockpars.num_of_atypes);
-	setKernelArg(kernel1,2, sizeof(dockpars.num_of_intraE_contributors),    &dockpars.num_of_intraE_contributors);
-	setKernelArg(kernel1,3, sizeof(dockpars.gridsize_x),                    &dockpars.gridsize_x);
-	setKernelArg(kernel1,4, sizeof(dockpars.gridsize_y),                    &dockpars.gridsize_y);
-	setKernelArg(kernel1,5, sizeof(dockpars.gridsize_z),                    &dockpars.gridsize_z);
-	setKernelArg(kernel1,6, sizeof(g2),                    		  	&g2);
-	setKernelArg(kernel1,7, sizeof(g3),                    		  	&g3);
-	setKernelArg(kernel1,8, sizeof(dockpars.grid_spacing),                  &dockpars.grid_spacing);
-	setKernelArg(kernel1,9, sizeof(mem_dockpars_fgrids),                    &mem_dockpars_fgrids);
-	setKernelArg(kernel1,10,sizeof(dockpars.rotbondlist_length),            &dockpars.rotbondlist_length);
-	setKernelArg(kernel1,11,sizeof(dockpars.coeff_elec),                    &dockpars.coeff_elec);
-	setKernelArg(kernel1,12,sizeof(dockpars.coeff_desolv),                  &dockpars.coeff_desolv);
-	setKernelArg(kernel1,13,sizeof(mem_dockpars_conformations_current),     &mem_dockpars_conformations_current);
-	setKernelArg(kernel1,14,sizeof(mem_dockpars_energies_current),          &mem_dockpars_energies_current);
-	setKernelArg(kernel1,15,sizeof(mem_dockpars_evals_of_new_entities),     &mem_dockpars_evals_of_new_entities);
-	setKernelArg(kernel1,16,sizeof(dockpars.pop_size),                      &dockpars.pop_size);
-	setKernelArg(kernel1,17,sizeof(dockpars.qasp),                          &dockpars.qasp);
-	setKernelArg(kernel1,18,sizeof(dockpars.smooth),                        &dockpars.smooth);
-	
-	setKernelArg(kernel1,19,sizeof(mem_interintra_const),                 	&mem_interintra_const);
-  	setKernelArg(kernel1,20,sizeof(mem_intracontrib_const),          	&mem_intracontrib_const);
-  	setKernelArg(kernel1,21,sizeof(mem_intra_const),                        &mem_intra_const);
-  	setKernelArg(kernel1,22,sizeof(mem_rotlist_const),                      &mem_rotlist_const);
-  	setKernelArg(kernel1,23,sizeof(mem_conform_const),                 	&mem_conform_const);
-	kernel1_gxsize = blocksPerGridForEachEntity * threadsPerBlock;
-	kernel1_lxsize = threadsPerBlock;
+	uint32_t kernel1_gxsize = blocksPerGridForEachEntity * threadsPerBlock;
+	uint32_t kernel1_lxsize = threadsPerBlock;
 #ifdef DOCK_DEBUG
-	printf("%-25s %10s %8u %10s %4u\n", "K_INIT", "gSize: ", kernel1_gxsize, "lSize: ", kernel1_lxsize); fflush(stdout);
+	printf("%-25s %10s %8lu %10s %4u\n", "K_INIT", "gSize: ", kernel1_gxsize, "lSize: ", kernel1_lxsize); fflush(stdout);
 #endif
 	// End of Kernel1
 
 	// Kernel2
-  	setKernelArg(kernel2,0,sizeof(dockpars.pop_size),       		&dockpars.pop_size);
-  	setKernelArg(kernel2,1,sizeof(mem_dockpars_evals_of_new_entities),      &mem_dockpars_evals_of_new_entities);
-  	setKernelArg(kernel2,2,sizeof(mem_gpu_evals_of_runs),                   &mem_gpu_evals_of_runs);
-  	kernel2_gxsize = blocksPerGridForEachRun * threadsPerBlock;
-  	kernel2_lxsize = threadsPerBlock;
+  	uint32_t kernel2_gxsize = blocksPerGridForEachRun * threadsPerBlock;
+  	uint32_t kernel2_lxsize = threadsPerBlock;
 #ifdef DOCK_DEBUG
-	printf("%-25s %10s %8u %10s %4u\n", "K_EVAL", "gSize: ", kernel2_gxsize, "lSize: ",  kernel2_lxsize); fflush(stdout);
+	printf("%-25s %10s %8lu %10s %4u\n", "K_EVAL", "gSize: ", kernel2_gxsize, "lSize: ",  kernel2_lxsize); fflush(stdout);
 #endif
 	// End of Kernel2
 
 	// Kernel4
-  	setKernelArg(kernel4,0, sizeof(dockpars.num_of_atoms),                  &dockpars.num_of_atoms);
-  	setKernelArg(kernel4,1, sizeof(dockpars.num_of_atypes),                 &dockpars.num_of_atypes);
-  	setKernelArg(kernel4,2, sizeof(dockpars.num_of_intraE_contributors),    &dockpars.num_of_intraE_contributors);
-  	setKernelArg(kernel4,3, sizeof(dockpars.gridsize_x),                    &dockpars.gridsize_x);
-  	setKernelArg(kernel4,4, sizeof(dockpars.gridsize_y),                    &dockpars.gridsize_y);
-  	setKernelArg(kernel4,5, sizeof(dockpars.gridsize_z),                    &dockpars.gridsize_z);
-  	setKernelArg(kernel4,6, sizeof(g2),                    		  	&g2);
-  	setKernelArg(kernel4,7, sizeof(g3),                    		  	&g3);
-  	setKernelArg(kernel4,8, sizeof(dockpars.grid_spacing),                  &dockpars.grid_spacing);
-  	setKernelArg(kernel4,9, sizeof(mem_dockpars_fgrids),                    &mem_dockpars_fgrids);
-  	setKernelArg(kernel4,10,sizeof(dockpars.rotbondlist_length),            &dockpars.rotbondlist_length);
-  	setKernelArg(kernel4,11,sizeof(dockpars.coeff_elec),                    &dockpars.coeff_elec);
-  	setKernelArg(kernel4,12,sizeof(dockpars.coeff_desolv),                  &dockpars.coeff_desolv);
-  	setKernelArg(kernel4,13,sizeof(mem_dockpars_conformations_current),     &mem_dockpars_conformations_current);
-  	setKernelArg(kernel4,14,sizeof(mem_dockpars_energies_current),          &mem_dockpars_energies_current);
-  	setKernelArg(kernel4,15,sizeof(mem_dockpars_conformations_next),        &mem_dockpars_conformations_next);
-  	setKernelArg(kernel4,16,sizeof(mem_dockpars_energies_next),             &mem_dockpars_energies_next);
-  	setKernelArg(kernel4,17,sizeof(mem_dockpars_evals_of_new_entities),     &mem_dockpars_evals_of_new_entities);
-  	setKernelArg(kernel4,18,sizeof(mem_dockpars_prng_states),               &mem_dockpars_prng_states);
-  	setKernelArg(kernel4,19,sizeof(dockpars.pop_size),                      &dockpars.pop_size);
-  	setKernelArg(kernel4,20,sizeof(dockpars.num_of_genes),                  &dockpars.num_of_genes);
-  	setKernelArg(kernel4,21,sizeof(dockpars.tournament_rate),               &dockpars.tournament_rate);
-  	setKernelArg(kernel4,22,sizeof(dockpars.crossover_rate),                &dockpars.crossover_rate);
-  	setKernelArg(kernel4,23,sizeof(dockpars.mutation_rate),                 &dockpars.mutation_rate);
-  	setKernelArg(kernel4,24,sizeof(dockpars.abs_max_dmov),                  &dockpars.abs_max_dmov);
-  	setKernelArg(kernel4,25,sizeof(dockpars.abs_max_dang),                  &dockpars.abs_max_dang);
-  	setKernelArg(kernel4,26,sizeof(dockpars.qasp),                          &dockpars.qasp);
-  	setKernelArg(kernel4,27,sizeof(dockpars.smooth),                        &dockpars.smooth);
-
-  	setKernelArg(kernel4,28,sizeof(mem_interintra_const),                 	&mem_interintra_const);
-  	setKernelArg(kernel4,29,sizeof(mem_intracontrib_const),          	&mem_intracontrib_const);
-  	setKernelArg(kernel4,30,sizeof(mem_intra_const),                        &mem_intra_const);
-  	setKernelArg(kernel4,31,sizeof(mem_rotlist_const),                      &mem_rotlist_const);
-  	setKernelArg(kernel4,32,sizeof(mem_conform_const),                 	&mem_conform_const);
-  	kernel4_gxsize = blocksPerGridForEachEntity * threadsPerBlock;
-  	kernel4_lxsize = threadsPerBlock;
+  	uint32_t kernel4_gxsize = blocksPerGridForEachEntity * threadsPerBlock;
+  	uint32_t kernel4_lxsize = threadsPerBlock;
 #ifdef DOCK_DEBUG
 	printf("%-25s %10s %8u %10s %4u\n", "K_GA_GENERATION", "gSize: ",  kernel4_gxsize, "lSize: ", kernel4_lxsize); fflush(stdout);
 #endif
 	// End of Kernel4
 
-
-	if (dockpars.lsearch_rate != 0.0f) {
+    uint32_t kernel3_gxsize, kernel3_lxsize;
+    uint32_t kernel5_gxsize, kernel5_lxsize;
+    uint32_t kernel6_gxsize, kernel6_lxsize;
+    uint32_t kernel7_gxsize, kernel7_lxsize;            
+	if (cData.dockpars.lsearch_rate != 0.0f) {
 
 		if (strcmp(mypars->ls_method, "sw") == 0) {
 			// Kernel3
-  			setKernelArg(kernel3,0, sizeof(dockpars.num_of_atoms),                  &dockpars.num_of_atoms);
-  			setKernelArg(kernel3,1, sizeof(dockpars.num_of_atypes),                 &dockpars.num_of_atypes);
-  			setKernelArg(kernel3,2, sizeof(dockpars.num_of_intraE_contributors),    &dockpars.num_of_intraE_contributors);
-	 	 	setKernelArg(kernel3,3, sizeof(dockpars.gridsize_x),                    &dockpars.gridsize_x);
-  			setKernelArg(kernel3,4, sizeof(dockpars.gridsize_y),                    &dockpars.gridsize_y);
-  			setKernelArg(kernel3,5, sizeof(dockpars.gridsize_z),                    &dockpars.gridsize_z);
-  			setKernelArg(kernel3,6, sizeof(g2),                    		  	&g2);
-  			setKernelArg(kernel3,7, sizeof(g3),                    		  	&g3);
-  			setKernelArg(kernel3,8, sizeof(dockpars.grid_spacing),                  &dockpars.grid_spacing);
-  			setKernelArg(kernel3,9, sizeof(mem_dockpars_fgrids),                    &mem_dockpars_fgrids);
-  			setKernelArg(kernel3,10,sizeof(dockpars.rotbondlist_length),            &dockpars.rotbondlist_length);
-			setKernelArg(kernel3,11,sizeof(dockpars.coeff_elec),                    &dockpars.coeff_elec);
-			setKernelArg(kernel3,12,sizeof(dockpars.coeff_desolv),                  &dockpars.coeff_desolv);
-			setKernelArg(kernel3,13,sizeof(mem_dockpars_conformations_next),        &mem_dockpars_conformations_next);
-			setKernelArg(kernel3,14,sizeof(mem_dockpars_energies_next),             &mem_dockpars_energies_next);
-			setKernelArg(kernel3,15,sizeof(mem_dockpars_evals_of_new_entities),     &mem_dockpars_evals_of_new_entities);
-			setKernelArg(kernel3,16,sizeof(mem_dockpars_prng_states),               &mem_dockpars_prng_states);
-			setKernelArg(kernel3,17,sizeof(dockpars.pop_size),                      &dockpars.pop_size);
-			setKernelArg(kernel3,18,sizeof(dockpars.num_of_genes),                  &dockpars.num_of_genes);
-			setKernelArg(kernel3,19,sizeof(dockpars.lsearch_rate),                  &dockpars.lsearch_rate);
-			setKernelArg(kernel3,20,sizeof(dockpars.num_of_lsentities),             &dockpars.num_of_lsentities);
-			setKernelArg(kernel3,21,sizeof(dockpars.rho_lower_bound),               &dockpars.rho_lower_bound);
-			setKernelArg(kernel3,22,sizeof(dockpars.base_dmov_mul_sqrt3),           &dockpars.base_dmov_mul_sqrt3);
-			setKernelArg(kernel3,23,sizeof(dockpars.base_dang_mul_sqrt3),           &dockpars.base_dang_mul_sqrt3);
-			setKernelArg(kernel3,24,sizeof(dockpars.cons_limit),                    &dockpars.cons_limit);
-			setKernelArg(kernel3,25,sizeof(dockpars.max_num_of_iters),              &dockpars.max_num_of_iters);
-			setKernelArg(kernel3,26,sizeof(dockpars.qasp),                          &dockpars.qasp);
-			setKernelArg(kernel3,27,sizeof(dockpars.smooth),                        &dockpars.smooth);
-
-	  		setKernelArg(kernel3,28,sizeof(mem_interintra_const),                 	&mem_interintra_const);
-		  	setKernelArg(kernel3,29,sizeof(mem_intracontrib_const),          	&mem_intracontrib_const);
-	  		setKernelArg(kernel3,30,sizeof(mem_intra_const),                        &mem_intra_const);
-	  		setKernelArg(kernel3,31,sizeof(mem_rotlist_const),                      &mem_rotlist_const);
-	  		setKernelArg(kernel3,32,sizeof(mem_conform_const),                 	&mem_conform_const);
 			kernel3_gxsize = blocksPerGridForEachLSEntity * threadsPerBlock;
 			kernel3_lxsize = threadsPerBlock;
   			#ifdef DOCK_DEBUG
@@ -776,44 +536,6 @@ filled with clock() */
 			// End of Kernel3
 		} else if (strcmp(mypars->ls_method, "sd") == 0) {
 			// Kernel5
-  			setKernelArg(kernel5,0, sizeof(dockpars.num_of_atoms),                   &dockpars.num_of_atoms);
-  			setKernelArg(kernel5,1, sizeof(dockpars.num_of_atypes),                  &dockpars.num_of_atypes);
-  			setKernelArg(kernel5,2, sizeof(dockpars.num_of_intraE_contributors),     &dockpars.num_of_intraE_contributors);
-  			setKernelArg(kernel5,3, sizeof(dockpars.gridsize_x),                     &dockpars.gridsize_x);
-  			setKernelArg(kernel5,4, sizeof(dockpars.gridsize_y),                     &dockpars.gridsize_y);
-  			setKernelArg(kernel5,5, sizeof(dockpars.gridsize_z),                     &dockpars.gridsize_z);
-  			setKernelArg(kernel5,6, sizeof(g2),                    		   	 &g2);
-  			setKernelArg(kernel5,7, sizeof(g3),                    		   	 &g3);
-  			setKernelArg(kernel5,8, sizeof(dockpars.grid_spacing),                   &dockpars.grid_spacing);
-  			setKernelArg(kernel5,9, sizeof(mem_dockpars_fgrids),                     &mem_dockpars_fgrids);
-  			setKernelArg(kernel5,10,sizeof(dockpars.rotbondlist_length),             &dockpars.rotbondlist_length);
-  			setKernelArg(kernel5,11,sizeof(dockpars.coeff_elec),                     &dockpars.coeff_elec);
-  			setKernelArg(kernel5,12,sizeof(dockpars.coeff_desolv),                   &dockpars.coeff_desolv);
-  			setKernelArg(kernel5,13,sizeof(mem_dockpars_conformations_next),         &mem_dockpars_conformations_next);
-  			setKernelArg(kernel5,14,sizeof(mem_dockpars_energies_next),              &mem_dockpars_energies_next);
-  			setKernelArg(kernel5,15,sizeof(mem_dockpars_evals_of_new_entities),      &mem_dockpars_evals_of_new_entities);
-  			setKernelArg(kernel5,16,sizeof(mem_dockpars_prng_states),                &mem_dockpars_prng_states);
-  			setKernelArg(kernel5,17,sizeof(dockpars.pop_size),                       &dockpars.pop_size);
-  			setKernelArg(kernel5,18,sizeof(dockpars.num_of_genes),                   &dockpars.num_of_genes);
-  			setKernelArg(kernel5,19,sizeof(dockpars.lsearch_rate),                   &dockpars.lsearch_rate);
-  			setKernelArg(kernel5,20,sizeof(dockpars.num_of_lsentities),              &dockpars.num_of_lsentities);
-  			setKernelArg(kernel5,21,sizeof(dockpars.max_num_of_iters),               &dockpars.max_num_of_iters);
-  			setKernelArg(kernel5,22,sizeof(dockpars.qasp),                           &dockpars.qasp);
-			setKernelArg(kernel5,23,sizeof(dockpars.smooth),                         &dockpars.smooth);
-
-	  		setKernelArg(kernel5,24,sizeof(mem_interintra_const),                 	 &mem_interintra_const);
-		  	setKernelArg(kernel5,25,sizeof(mem_intracontrib_const),          	 &mem_intracontrib_const);
-	  		setKernelArg(kernel5,26,sizeof(mem_intra_const),                         &mem_intra_const);
-	  		setKernelArg(kernel5,27,sizeof(mem_rotlist_const),                       &mem_rotlist_const);
-	  		setKernelArg(kernel5,28,sizeof(mem_conform_const),                 	 &mem_conform_const);
-
-  			setKernelArg(kernel5,29,sizeof(mem_rotbonds_const),         		 &mem_rotbonds_const);
-  			setKernelArg(kernel5,30,sizeof(mem_rotbonds_atoms_const),   		 &mem_rotbonds_atoms_const);
-  			setKernelArg(kernel5,31,sizeof(mem_num_rotating_atoms_per_rotbond_const),&mem_num_rotating_atoms_per_rotbond_const);
-  			setKernelArg(kernel5,32,sizeof(mem_angle_const),			 &mem_angle_const);
-  			setKernelArg(kernel5,33,sizeof(mem_dependence_on_theta_const),		 &mem_dependence_on_theta_const);
-  			setKernelArg(kernel5,34,sizeof(mem_dependence_on_rotangle_const),  	 &mem_dependence_on_rotangle_const);
-
   			kernel5_gxsize = blocksPerGridForEachGradMinimizerEntity * threadsPerBlock;
   			kernel5_lxsize = threadsPerBlock;
 			#ifdef DOCK_DEBUG
@@ -822,43 +544,6 @@ filled with clock() */
 			// End of Kernel5
 		} else if (strcmp(mypars->ls_method, "fire") == 0) {
 			// Kernel6
-  			setKernelArg(kernel6,0, sizeof(dockpars.num_of_atoms),                   &dockpars.num_of_atoms);
-  			setKernelArg(kernel6,1, sizeof(dockpars.num_of_atypes),                  &dockpars.num_of_atypes);
-  			setKernelArg(kernel6,2, sizeof(dockpars.num_of_intraE_contributors),     &dockpars.num_of_intraE_contributors);
-  			setKernelArg(kernel6,3, sizeof(dockpars.gridsize_x),                     &dockpars.gridsize_x);
-  			setKernelArg(kernel6,4, sizeof(dockpars.gridsize_y),                     &dockpars.gridsize_y);
-  			setKernelArg(kernel6,5, sizeof(dockpars.gridsize_z),                     &dockpars.gridsize_z);
-  			setKernelArg(kernel6,6, sizeof(g2),                    		   	 &g2);
-  			setKernelArg(kernel6,7, sizeof(g3),                    		   	 &g3);
-  			setKernelArg(kernel6,8, sizeof(dockpars.grid_spacing),                   &dockpars.grid_spacing);
-  			setKernelArg(kernel6,9, sizeof(mem_dockpars_fgrids),                     &mem_dockpars_fgrids);
-  			setKernelArg(kernel6,10,sizeof(dockpars.rotbondlist_length),             &dockpars.rotbondlist_length);
-  			setKernelArg(kernel6,11,sizeof(dockpars.coeff_elec),                     &dockpars.coeff_elec);
-  			setKernelArg(kernel6,12,sizeof(dockpars.coeff_desolv),                   &dockpars.coeff_desolv);
-  			setKernelArg(kernel6,13,sizeof(mem_dockpars_conformations_next),         &mem_dockpars_conformations_next);
-  			setKernelArg(kernel6,14,sizeof(mem_dockpars_energies_next),              &mem_dockpars_energies_next);
-  			setKernelArg(kernel6,15,sizeof(mem_dockpars_evals_of_new_entities),      &mem_dockpars_evals_of_new_entities);
-  			setKernelArg(kernel6,16,sizeof(mem_dockpars_prng_states),                &mem_dockpars_prng_states);
-  			setKernelArg(kernel6,17,sizeof(dockpars.pop_size),                       &dockpars.pop_size);
-  			setKernelArg(kernel6,18,sizeof(dockpars.num_of_genes),                   &dockpars.num_of_genes);
-  			setKernelArg(kernel6,19,sizeof(dockpars.lsearch_rate),                   &dockpars.lsearch_rate);
-  			setKernelArg(kernel6,20,sizeof(dockpars.num_of_lsentities),              &dockpars.num_of_lsentities);
-  			setKernelArg(kernel6,21,sizeof(dockpars.max_num_of_iters),               &dockpars.max_num_of_iters);
-  			setKernelArg(kernel6,22,sizeof(dockpars.qasp),                           &dockpars.qasp);
-  			setKernelArg(kernel6,23,sizeof(dockpars.smooth),                         &dockpars.smooth);
-
-	  		setKernelArg(kernel6,24,sizeof(mem_interintra_const),                 	 &mem_interintra_const);
-		  	setKernelArg(kernel6,25,sizeof(mem_intracontrib_const),          	 &mem_intracontrib_const);
-	  		setKernelArg(kernel6,26,sizeof(mem_intra_const),                         &mem_intra_const);
-	  		setKernelArg(kernel6,27,sizeof(mem_rotlist_const),                       &mem_rotlist_const);
-	  		setKernelArg(kernel6,28,sizeof(mem_conform_const),                 	 &mem_conform_const);
-
-  			setKernelArg(kernel6,29,sizeof(mem_rotbonds_const),         		 &mem_rotbonds_const);
-  			setKernelArg(kernel6,30,sizeof(mem_rotbonds_atoms_const),   		 &mem_rotbonds_atoms_const);
-  			setKernelArg(kernel6,31,sizeof(mem_num_rotating_atoms_per_rotbond_const),&mem_num_rotating_atoms_per_rotbond_const);
-  			setKernelArg(kernel6,32,sizeof(mem_angle_const),			 &mem_angle_const);
-  			setKernelArg(kernel6,33,sizeof(mem_dependence_on_theta_const),		 &mem_dependence_on_theta_const);
-  			setKernelArg(kernel6,34,sizeof(mem_dependence_on_rotangle_const),	 &mem_dependence_on_rotangle_const);
   			kernel6_gxsize = blocksPerGridForEachGradMinimizerEntity * threadsPerBlock;
   			kernel6_lxsize = threadsPerBlock;
 			#ifdef DOCK_DEBUG
@@ -867,43 +552,6 @@ filled with clock() */
 			// End of Kernel6
 		} else if (strcmp(mypars->ls_method, "ad") == 0) {
 			// Kernel7
-			setKernelArg(kernel7,0, sizeof(dockpars.num_of_atoms),                   &dockpars.num_of_atoms);
-			setKernelArg(kernel7,1, sizeof(dockpars.num_of_atypes),                  &dockpars.num_of_atypes);
-			setKernelArg(kernel7,2, sizeof(dockpars.num_of_intraE_contributors),     &dockpars.num_of_intraE_contributors);
-			setKernelArg(kernel7,3, sizeof(dockpars.gridsize_x),                     &dockpars.gridsize_x);
-			setKernelArg(kernel7,4, sizeof(dockpars.gridsize_y),                     &dockpars.gridsize_y);
-			setKernelArg(kernel7,5, sizeof(dockpars.gridsize_z),                     &dockpars.gridsize_z);
-			setKernelArg(kernel7,6, sizeof(g2),                    		   	 &g2);
-			setKernelArg(kernel7,7, sizeof(g3),                    		   	 &g3);
-			setKernelArg(kernel7,8, sizeof(dockpars.grid_spacing),                   &dockpars.grid_spacing);
-			setKernelArg(kernel7,9, sizeof(mem_dockpars_fgrids),                     &mem_dockpars_fgrids);
-			setKernelArg(kernel7,10,sizeof(dockpars.rotbondlist_length),             &dockpars.rotbondlist_length);
-			setKernelArg(kernel7,11,sizeof(dockpars.coeff_elec),                     &dockpars.coeff_elec);
-			setKernelArg(kernel7,12,sizeof(dockpars.coeff_desolv),                   &dockpars.coeff_desolv);
-			setKernelArg(kernel7,13,sizeof(mem_dockpars_conformations_next),         &mem_dockpars_conformations_next);
-			setKernelArg(kernel7,14,sizeof(mem_dockpars_energies_next),              &mem_dockpars_energies_next);
-			setKernelArg(kernel7,15,sizeof(mem_dockpars_evals_of_new_entities),      &mem_dockpars_evals_of_new_entities);
-			setKernelArg(kernel7,16,sizeof(mem_dockpars_prng_states),                &mem_dockpars_prng_states);
-			setKernelArg(kernel7,17,sizeof(dockpars.pop_size),                       &dockpars.pop_size);
-			setKernelArg(kernel7,18,sizeof(dockpars.num_of_genes),                   &dockpars.num_of_genes);
-			setKernelArg(kernel7,19,sizeof(dockpars.lsearch_rate),                   &dockpars.lsearch_rate);
-			setKernelArg(kernel7,20,sizeof(dockpars.num_of_lsentities),              &dockpars.num_of_lsentities);
-			setKernelArg(kernel7,21,sizeof(dockpars.max_num_of_iters),               &dockpars.max_num_of_iters);
-			setKernelArg(kernel7,22,sizeof(dockpars.qasp),                           &dockpars.qasp);
-			setKernelArg(kernel7,23,sizeof(dockpars.smooth),                         &dockpars.smooth);
-
-			setKernelArg(kernel7,24,sizeof(mem_interintra_const),                 	 &mem_interintra_const);
-			setKernelArg(kernel7,25,sizeof(mem_intracontrib_const),          	 &mem_intracontrib_const);
-			setKernelArg(kernel7,26,sizeof(mem_intra_const),                         &mem_intra_const);
-			setKernelArg(kernel7,27,sizeof(mem_rotlist_const),                       &mem_rotlist_const);
-			setKernelArg(kernel7,28,sizeof(mem_conform_const),                 	 &mem_conform_const);
-
-			setKernelArg(kernel7,29,sizeof(mem_rotbonds_const),         		 &mem_rotbonds_const);
-			setKernelArg(kernel7,30,sizeof(mem_rotbonds_atoms_const),   		 &mem_rotbonds_atoms_const);
-			setKernelArg(kernel7,31,sizeof(mem_num_rotating_atoms_per_rotbond_const),&mem_num_rotating_atoms_per_rotbond_const);
-			setKernelArg(kernel7,32,sizeof(mem_angle_const),			 &mem_angle_const);
-			setKernelArg(kernel7,33,sizeof(mem_dependence_on_theta_const),		 &mem_dependence_on_theta_const);
-			setKernelArg(kernel7,34,sizeof(mem_dependence_on_rotangle_const),	 &mem_dependence_on_rotangle_const);
 			kernel7_gxsize = blocksPerGridForEachGradMinimizerEntity * threadsPerBlock;
 			kernel7_lxsize = threadsPerBlock;
 			#ifdef DOCK_DEBUG
@@ -917,9 +565,12 @@ filled with clock() */
 	#ifdef DOCK_DEBUG
 		printf("\nExecution starts:\n\n");
 		printf("%-25s", "\tK_INIT");fflush(stdout);
+        cudaDeviceSynchronize();
 	#endif
-	runKernel1D(command_queue,kernel1,kernel1_gxsize,kernel1_lxsize,&time_start_kernel,&time_end_kernel);
+    gpu_calc_initpop(kernel1_gxsize, kernel1_lxsize, pMem_conformations_current, pMem_energies_current);
+	//runKernel1D(command_queue,kernel1,kernel1_gxsize,kernel1_lxsize,&time_start_kernel,&time_end_kernel);
 	#ifdef DOCK_DEBUG
+        cudaDeviceSynchronize();
 		printf("%15s" ," ... Finished\n");fflush(stdout);
 	#endif
 	// End of Kernel1
@@ -928,22 +579,16 @@ filled with clock() */
 	#ifdef DOCK_DEBUG
 		printf("%-25s", "\tK_EVAL");fflush(stdout);
 	#endif
-	runKernel1D(command_queue,kernel2,kernel2_gxsize,kernel2_lxsize,&time_start_kernel,&time_end_kernel);
+	//runKernel1D(command_queue,kernel2,kernel2_gxsize,kernel2_lxsize,&time_start_kernel,&time_end_kernel);
+    gpu_sum_evals(kernel2_gxsize, kernel2_lxsize);
 	#ifdef DOCK_DEBUG
+        cudaDeviceSynchronize();
 		printf("%15s" ," ... Finished\n");fflush(stdout);
 	#endif
 	// End of Kernel2
 	// ===============================================================================
 
 
-	// -------- Replacing with memory maps! ------------
-#if defined (MAPPED_COPY)
-	int* map_cpu_evals_of_runs;
-	map_cpu_evals_of_runs = (int*) memMap(command_queue, mem_gpu_evals_of_runs, CL_MAP_READ, size_evals_of_runs);
-#else
-	memcopyBufferObjectFromDevice(command_queue,cpu_evals_of_runs,mem_gpu_evals_of_runs,size_evals_of_runs);
-#endif
-	// -------- Replacing with memory maps! ------------
 	#if 0
 	generation_cnt = 1;
 	#endif
@@ -968,19 +613,21 @@ filled with clock() */
 	unsigned int avg_arr_size = (Ntop+1)*3;
 	float average_sd2_N[avg_arr_size];
 	unsigned long total_evals;
-	bool autostopped = false;
+
+    auto const t2 = std::chrono::steady_clock::now();
+    printf("Rest of Setup time %fs\n", elapsed_seconds(t1 ,t2));
+
+
 	// -------- Replacing with memory maps! ------------
-#if defined (MAPPED_COPY)
-	while ((progress = check_progress(map_cpu_evals_of_runs, generation_cnt, mypars->num_of_energy_evals, mypars->num_of_generations, mypars->num_of_runs, total_evals)) < 100.0)
-#else
-	while ((progress = check_progress(cpu_evals_of_runs, generation_cnt, mypars->num_of_energy_evals, mypars->num_of_generations, mypars->num_of_runs, total_evals)) < 100.0)
-#endif
+	while ((progress = check_progress(pMem_gpu_evals_of_runs, generation_cnt, mypars->num_of_energy_evals, mypars->num_of_generations, mypars->num_of_runs, total_evals)) < 100.0)
 	// -------- Replacing with memory maps! ------------
 	{
 		if (mypars->autostop)
 		{
 			if (generation_cnt % 10 == 0) {
-				memcopyBufferObjectFromDevice(command_queue,cpu_energies,mem_dockpars_energies_current,size_energies);
+                cudaError_t status;
+                cudaMemcpy(cpu_energies, pMem_energies_current, size_energies, cudaMemcpyDeviceToHost);
+                RTERROR(status, "cudaMemcpy: couldn't downloaded pMem_energies_current");
 				for(unsigned int count=0; (count<1+8*(generation_cnt==0)) && (fabs(curr_avg-prev_avg)>0.00001); count++)
 				{
 					threshold_used = threshold;
@@ -1058,7 +705,7 @@ filled with clock() */
 						delta_energy = 2.0 * thres_stddev / (Ntop-1);
 					}
 				}
-				printf("%11u | %12u |%8.2f kcal/mol |%8.2f +/-%8.2f kcal/mol |%8i |%8.2f kcal/mol\n",generation_cnt,total_evals/mypars->num_of_runs,threshold_used,curr_avg,curr_std,bestN,overall_best_energy);
+				printf("%11lu | %12d |%8.2f kcal/mol |%8.2f +/-%8.2f kcal/mol |%8i |%8.2f kcal/mol\n",generation_cnt,total_evals/mypars->num_of_runs,threshold_used,curr_avg,curr_std,bestN,overall_best_energy);
 				fflush(stdout);
 				rolling[3*roll_count] = curr_avg * bestN;
 				rolling[3*roll_count+1] = (curr_std*curr_std + curr_avg*curr_avg)*bestN;
@@ -1073,7 +720,6 @@ filled with clock() */
 					printf("------------+--------------+------------------+------------------------------+---------+-------------------\n");
 					printf("\n%43s evaluation after reaching\n%40.2f +/-%8.2f kcal/mol combined.\n%34i samples, best energy %8.2f kcal/mol.\n","Finished",average(&average_sd2_N[0]),stddev(&average_sd2_N[0]),(unsigned int)average_sd2_N[2],overall_best_energy);
 					fflush(stdout);
-					autostopped = true;
 					break;
 				}
 			}
@@ -1101,18 +747,20 @@ filled with clock() */
 		#ifdef DOCK_DEBUG
 			printf("%-25s", "\tK_GA_GENERATION");fflush(stdout);
 		#endif
-		runKernel1D(command_queue,kernel4,kernel4_gxsize,kernel4_lxsize,&time_start_kernel,&time_end_kernel);
+        
+		//runKernel1D(command_queue,kernel4,kernel4_gxsize,kernel4_lxsize,&time_start_kernel,&time_end_kernel);
+        gpu_gen_and_eval_newpops(kernel4_gxsize, kernel4_lxsize, pMem_conformations_current, pMem_energies_current, pMem_conformations_next, pMem_energies_next);
 		#ifdef DOCK_DEBUG
 			printf("%15s", " ... Finished\n");fflush(stdout);
 		#endif
 		// End of Kernel4
-		if (dockpars.lsearch_rate != 0.0f) {
+		if (cData.dockpars.lsearch_rate != 0.0f) {
 			if (strcmp(mypars->ls_method, "sw") == 0) {
 				// Kernel3
 				#ifdef DOCK_DEBUG
 					printf("%-25s", "\tK_LS_SOLISWETS");fflush(stdout);
 				#endif
-				runKernel1D(command_queue,kernel3,kernel3_gxsize,kernel3_lxsize,&time_start_kernel,&time_end_kernel);
+				//runKernel1D(command_queue,kernel3,kernel3_gxsize,kernel3_lxsize,&time_start_kernel,&time_end_kernel);
 				#ifdef DOCK_DEBUG
 					printf("%15s" ," ... Finished\n");fflush(stdout);
 				#endif
@@ -1122,7 +770,7 @@ filled with clock() */
 				#ifdef DOCK_DEBUG
 					printf("%-25s", "\tK_LS_GRAD_SDESCENT");fflush(stdout);
 				#endif
-				runKernel1D(command_queue,kernel5,kernel5_gxsize,kernel5_lxsize,&time_start_kernel,&time_end_kernel);
+				//runKernel1D(command_queue,kernel5,kernel5_gxsize,kernel5_lxsize,&time_start_kernel,&time_end_kernel);
 				#ifdef DOCK_DEBUG
 					printf("%15s" ," ... Finished\n");fflush(stdout);
 				#endif
@@ -1132,7 +780,7 @@ filled with clock() */
 				#ifdef DOCK_DEBUG
 					printf("%-25s", "\tK_LS_GRAD_FIRE");fflush(stdout);
 				#endif
-				runKernel1D(command_queue,kernel6,kernel6_gxsize,kernel6_lxsize,&time_start_kernel,&time_end_kernel);
+				//runKernel1D(command_queue,kernel6,kernel6_gxsize,kernel6_lxsize,&time_start_kernel,&time_end_kernel);
 				#ifdef DOCK_DEBUG
 					printf("%15s" ," ... Finished\n");fflush(stdout);
 				#endif
@@ -1142,7 +790,7 @@ filled with clock() */
 				#ifdef DOCK_DEBUG
 					printf("%-25s", "\tK_LS_GRAD_ADADELTA");fflush(stdout);
 				#endif
-				runKernel1D(command_queue,kernel7,kernel7_gxsize,kernel7_lxsize,&time_start_kernel,&time_end_kernel);
+                // runKernel1D(command_queue,kernel7,kernel7_gxsize,kernel7_lxsize,&time_start_kernel,&time_end_kernel);
 				#ifdef DOCK_DEBUG
 					printf("%15s" ," ... Finished\n");fflush(stdout);
 				#endif
@@ -1150,15 +798,14 @@ filled with clock() */
 			}
 		} // End if (dockpars.lsearch_rate != 0.0f)
 		// -------- Replacing with memory maps! ------------
-		#if defined (MAPPED_COPY)
-		unmemMap(command_queue,mem_gpu_evals_of_runs,map_cpu_evals_of_runs);
-		#endif
 		// -------- Replacing with memory maps! ------------
 		// Kernel2
 		#ifdef DOCK_DEBUG
 			printf("%-25s", "\tK_EVAL");fflush(stdout);
 		#endif
-		runKernel1D(command_queue,kernel2,kernel2_gxsize,kernel2_lxsize,&time_start_kernel,&time_end_kernel);
+		//runKernel1D(command_queue,kernel2,kernel2_gxsize,kernel2_lxsize,&time_start_kernel,&time_end_kernel);
+        gpu_sum_evals(kernel2_gxsize, kernel2_lxsize);       
+        
 		#ifdef DOCK_DEBUG
 			printf("%15s" ," ... Finished\n");fflush(stdout);
 		#endif
@@ -1166,14 +813,14 @@ filled with clock() */
 		// ===============================================================================
 		// -------- Replacing with memory maps! ------------
 #if defined (MAPPED_COPY)
-		map_cpu_evals_of_runs = (int*) memMap(command_queue, mem_gpu_evals_of_runs, CL_MAP_READ, size_evals_of_runs);
+		//map_cpu_evals_of_runs = (int*) memMap(command_queue, mem_gpu_evals_of_runs, CL_MAP_READ, size_evals_of_runs);
 #else
-		memcopyBufferObjectFromDevice(command_queue,cpu_evals_of_runs,mem_gpu_evals_of_runs,size_evals_of_runs);
+		cudaMemcpy(cpu_evals_of_runs, pMem_gpu_evals_of_runs, size_evals_of_runs, cudaMemcpyDeviceToHost);
 #endif
 		// -------- Replacing with memory maps! ------------
 		generation_cnt++;
 		// ----------------------------------------------------------------------
-		// ORIGINAL APPROACH: switching conformation and energy pointers
+		// ORIGINAL APPROACH: switching conformation and energy pointers (Probably the best approach, restored)
 		// CURRENT APPROACH:  copy data from one buffer to another, pointers are kept the same
 		// IMPROVED CURRENT APPROACH
 		// Kernel arguments are changed on every iteration
@@ -1185,64 +832,27 @@ filled with clock() */
 		// Kernel args exchange regions they point to
 		// But never two args point to the same region of dev memory
 		// NO ALIASING -> use restrict in Kernel
-		if (generation_cnt % 2 == 0) { // In this configuration the program starts with generation_cnt = 0
-			// Kernel 4
-			setKernelArg(kernel4,13,sizeof(mem_dockpars_conformations_current),             &mem_dockpars_conformations_current);
-			setKernelArg(kernel4,14,sizeof(mem_dockpars_energies_current),                  &mem_dockpars_energies_current);
-			setKernelArg(kernel4,15,sizeof(mem_dockpars_conformations_next),                &mem_dockpars_conformations_next);
-			setKernelArg(kernel4,16,sizeof(mem_dockpars_energies_next),                     &mem_dockpars_energies_next);
-			if (dockpars.lsearch_rate != 0.0f) {
-				if (strcmp(mypars->ls_method, "sw") == 0) {
-					// Kernel 3
-					setKernelArg(kernel3,13,sizeof(mem_dockpars_conformations_next),		&mem_dockpars_conformations_next);
-					setKernelArg(kernel3,14,sizeof(mem_dockpars_energies_next),			&mem_dockpars_energies_next);
-				} else if (strcmp(mypars->ls_method, "sd") == 0) {
-					// Kernel 5
-					setKernelArg(kernel5,13,sizeof(mem_dockpars_conformations_next),                &mem_dockpars_conformations_next);
-					setKernelArg(kernel5,14,sizeof(mem_dockpars_energies_next),                     &mem_dockpars_energies_next);
-				} else if (strcmp(mypars->ls_method, "fire") == 0) {
-					// Kernel 6
-					setKernelArg(kernel6,13,sizeof(mem_dockpars_conformations_next),                &mem_dockpars_conformations_next);
-					setKernelArg(kernel6,14,sizeof(mem_dockpars_energies_next),                     &mem_dockpars_energies_next);
-				} else if (strcmp(mypars->ls_method, "ad") == 0) {
-					// Kernel 7
-					setKernelArg(kernel7,13,sizeof(mem_dockpars_conformations_next),                &mem_dockpars_conformations_next);
-					setKernelArg(kernel7,14,sizeof(mem_dockpars_energies_next),                     &mem_dockpars_energies_next);
-				}
-			} // End if (dockpars.lsearch_rate != 0.0f)
-		}
-		else {  // Program switches pointers the first time when generation_cnt becomes 1 (as it starts from 0)
-			// Kernel 4
-			setKernelArg(kernel4,13,sizeof(mem_dockpars_conformations_next),                &mem_dockpars_conformations_next);
-			setKernelArg(kernel4,14,sizeof(mem_dockpars_energies_next),                     &mem_dockpars_energies_next);
-			setKernelArg(kernel4,15,sizeof(mem_dockpars_conformations_current),             &mem_dockpars_conformations_current);
-			setKernelArg(kernel4,16,sizeof(mem_dockpars_energies_current),                  &mem_dockpars_energies_current);
-			if (dockpars.lsearch_rate != 0.0f) {
-				if (strcmp(mypars->ls_method, "sw") == 0) {
-						// Kernel 3
-						setKernelArg(kernel3,13,sizeof(mem_dockpars_conformations_current),	&mem_dockpars_conformations_current);
-						setKernelArg(kernel3,14,sizeof(mem_dockpars_energies_current),		&mem_dockpars_energies_current);
-				} else if (strcmp(mypars->ls_method, "sd") == 0) {
-						// Kernel 5
-						setKernelArg(kernel5,13,sizeof(mem_dockpars_conformations_current),	&mem_dockpars_conformations_current);
-						setKernelArg(kernel5,14,sizeof(mem_dockpars_energies_current),		&mem_dockpars_energies_current);
-				} else if (strcmp(mypars->ls_method, "fire") == 0) {
-						// Kernel 6
-						setKernelArg(kernel6,13,sizeof(mem_dockpars_conformations_current),	&mem_dockpars_conformations_current);
-						setKernelArg(kernel6,14,sizeof(mem_dockpars_energies_current),		&mem_dockpars_energies_current);
-				} else if (strcmp(mypars->ls_method, "ad") == 0) {
-						// Kernel 7
-						setKernelArg(kernel7,13,sizeof(mem_dockpars_conformations_current),	&mem_dockpars_conformations_current);
-			 			setKernelArg(kernel7,14,sizeof(mem_dockpars_energies_current),		&mem_dockpars_energies_current);
-				}
-			} // End if (dockpars.lsearch_rate != 0.0f)
-		}
+        
+        // Flip conformation and energy pointers
+        float* pTemp;
+        pTemp = pMem_conformations_current;
+        pMem_conformations_current = pMem_conformations_next;
+        pMem_conformations_next = pTemp;
+        pTemp = pMem_energies_current;
+        pMem_energies_current = pMem_energies_next;
+        pMem_energies_next = pTemp;
+               
 		// ----------------------------------------------------------------------
 		#ifdef DOCK_DEBUG
 			printf("\tProgress %.3f %%\n", progress);
 			fflush(stdout);
 		#endif
 	} // End of while-loop
+
+    auto const t3 = std::chrono::steady_clock::now();
+    printf("\nDocking time %fs\n", elapsed_seconds(t2, t3));
+
+
 	clock_stop_docking = clock();
 	if (mypars->autostop==0)
 	{
@@ -1253,76 +863,17 @@ filled with clock() */
 			fflush(stdout);
 		}
 	}
+	printf("\n\n");
 	// ===============================================================================
 	// Modification based on:
 	// http://www.cc.gatech.edu/~vetter/keeneland/tutorial-2012-02-20/08-opencl.pdf
 	// ===============================================================================
 	//processing results
-	if (generation_cnt % 2 == 0) {
-		memcopyBufferObjectFromDevice(command_queue,cpu_final_populations,mem_dockpars_conformations_current,size_populations);
-		memcopyBufferObjectFromDevice(command_queue,cpu_energies,mem_dockpars_energies_current,size_energies);
-	}
-	else { 
-		memcopyBufferObjectFromDevice(command_queue,cpu_final_populations,mem_dockpars_conformations_next,size_populations);
-		memcopyBufferObjectFromDevice(command_queue,cpu_energies,mem_dockpars_energies_next,size_energies);
-	}
-	if(mypars->autostop && !autostopped){ // at this point we still need to output the best energy for consistency ;-)
-		overall_best_energy = 1<<24;
-		for (run_cnt=0; run_cnt < mypars->num_of_runs; run_cnt++)
-		{
-			energies = cpu_energies+run_cnt*mypars->pop_size;
-			for (unsigned int i=0; i<mypars->pop_size; i++)
-			{
-				float energy = energies[i];
-				if(energy < overall_best_energy)
-					overall_best_energy = energy;
-				if(energy < threshold)
-				{
-					average_sd2_N[0] += energy;
-					average_sd2_N[1] += energy * energy;
-					average_sd2_N[2] += 1.0;
-					for(unsigned int m=0; m<Ntop; m++)
-						if(energy < (threshold-2.0*thres_stddev)+m*delta_energy)
-						{
-							average_sd2_N[3*(m+1)] += energy;
-							average_sd2_N[3*(m+1)+1] += energy*energy;
-							average_sd2_N[3*(m+1)+2] += 1.0;
-							break; // only one entry per bin
-						}
-				}
-			}
-		}
-		curr_avg = average(&average_sd2_N[0]);
-		curr_std = stddev(&average_sd2_N[0]);
-		bestN = average_sd2_N[2];
-		average_sd2_N[0] = 0.0;
-		average_sd2_N[1] = 0.0;
-		average_sd2_N[2] = 0.0;
-		unsigned int lowest_energy = 0;
-		for(unsigned int m=0; m<Ntop; m++)
-		{
-			if((average_sd2_N[3*(m+1)+2]>=1.0) && (lowest_energy<Ncream))
-			{
-				if((average_sd2_N[2]<4.0) || fabs(average(&average_sd2_N[0])-average(&average_sd2_N[3*(m+1)]))<2.0*mypars->stopstd)
-				{
-					average_sd2_N[0] += average_sd2_N[3*(m+1)];
-					average_sd2_N[1] += average_sd2_N[3*(m+1)+1];
-					average_sd2_N[2] += average_sd2_N[3*(m+1)+2];
-					lowest_energy++;
-				}
-			}
-		}
-		if(lowest_energy>0)
-		{
-			curr_avg = average(&average_sd2_N[0]);
-			curr_std = stddev(&average_sd2_N[0]);
-			bestN = average_sd2_N[2];
-		}
-		printf("%11u | %12u |%8.2f kcal/mol |%8.2f +/-%8.2f kcal/mol |%8i |%8.2f kcal/mol\n",generation_cnt,total_evals/mypars->num_of_runs,threshold,curr_avg,curr_std,bestN,overall_best_energy);
-		printf("------------+--------------+------------------+------------------------------+---------+-------------------\n");
-		printf("\n%43s evaluation after reaching\n%33u evaluations. Best energy %8.2f kcal/mol.\n","Finished",total_evals/mypars->num_of_runs,overall_best_energy);
-	}
-	printf("\n\n");
+    status = cudaMemcpy(cpu_final_populations, pMem_conformations_current, size_populations, cudaMemcpyDeviceToHost);
+    RTERROR(status, "cudaMemcpy: couldn't copy pMem_conformations_current to host.\n");
+    status = cudaMemcpy(cpu_energies, pMem_energies_current, size_energies, cudaMemcpyDeviceToHost);
+    RTERROR(status, "cudaMemcpy: couldn't copy pMem_energies_current to host.\n");
+
 #if defined (DOCK_DEBUG)
 	for (int cnt_pop=0;cnt_pop<size_populations/sizeof(float);cnt_pop++)
 		printf("total_num_pop: %u, cpu_final_populations[%u]: %f\n",(unsigned int)(size_populations/sizeof(float)),cnt_pop,cpu_final_populations[cnt_pop]);
@@ -1355,76 +906,38 @@ filled with clock() */
 					 mygrid, argc, argv, ELAPSEDSECS(clock_stop_docking, clock_start_docking)/mypars->num_of_runs,
 					 ELAPSEDSECS(clock_stop_program_before_clustering, clock_start_program),generation_cnt,total_evals/mypars->num_of_runs);
 	clock_stop_docking = clock();
-/*
-	clReleaseMemObject(mem_atom_charges_const);
-        clReleaseMemObject(mem_atom_types_const);
-        clReleaseMemObject(mem_intraE_contributors_const);
-  	clReleaseMemObject(mem_reqm_const);
-  	clReleaseMemObject(mem_reqm_hbond_const);
-  	clReleaseMemObject(mem_atom1_types_reqm_const);
-  	clReleaseMemObject(mem_atom2_types_reqm_const);
-        clReleaseMemObject(mem_VWpars_AC_const);
-	clReleaseMemObject(mem_VWpars_BD_const);
-	clReleaseMemObject(mem_dspars_S_const);
-	clReleaseMemObject(mem_dspars_V_const);
-        clReleaseMemObject(mem_rotlist_const);
-	clReleaseMemObject(mem_ref_coords_x_const);
-	clReleaseMemObject(mem_ref_coords_y_const);
-	clReleaseMemObject(mem_ref_coords_z_const);
-	clReleaseMemObject(mem_rotbonds_moving_vectors_const);
-	clReleaseMemObject(mem_rotbonds_unit_vectors_const);
-	clReleaseMemObject(mem_ref_orientation_quats_const);
-*/
-
-	clReleaseMemObject(mem_interintra_const);
-	clReleaseMemObject(mem_intracontrib_const);
-	clReleaseMemObject(mem_intra_const);
-	clReleaseMemObject(mem_rotlist_const);
-	clReleaseMemObject(mem_conform_const);
-
-	clReleaseMemObject(mem_rotbonds_const);
-	clReleaseMemObject(mem_rotbonds_atoms_const);
-	clReleaseMemObject(mem_num_rotating_atoms_per_rotbond_const);
-
-	clReleaseMemObject(mem_dockpars_fgrids);
-	clReleaseMemObject(mem_dockpars_conformations_current);
-	clReleaseMemObject(mem_dockpars_energies_current);
-	clReleaseMemObject(mem_dockpars_conformations_next);
-	clReleaseMemObject(mem_dockpars_energies_next);
-	clReleaseMemObject(mem_dockpars_evals_of_new_entities);
-	clReleaseMemObject(mem_dockpars_prng_states);
-	clReleaseMemObject(mem_gpu_evals_of_runs);
-	/*
-	clReleaseMemObject(mem_gradpars_conformation_min_perturbation);
-	*/
-	clReleaseMemObject(mem_angle_const);
-	clReleaseMemObject(mem_dependence_on_theta_const);
-	clReleaseMemObject(mem_dependence_on_rotangle_const);
-
-	// Release all kernels,
-	// regardless of the chosen local-search method for execution.
-	// Otherwise, memory leak in clCreateKernel()
-	clReleaseKernel(kernel1);
-	clReleaseKernel(kernel2);
-	clReleaseKernel(kernel3);
-	clReleaseKernel(kernel4);
-	clReleaseKernel(kernel5);
-	clReleaseKernel(kernel6);
-	clReleaseKernel(kernel7);
-
-	clReleaseProgram(program);
-	
-	clReleaseCommandQueue(command_queue);
-	clReleaseContext(context);
-	free(device_ids);
-	free(platform_id);
-
+    
+    
+    
+    // Release all CUDA objects
+    status = cudaFree(pMem_fgrids);
+    RTERROR(status, "cudaFree: error freeing pMem_fgrids");
+    status = cudaFree(pMem_conformations1);
+    RTERROR(status, "cudaFree: error freeing pMem_conformations1");
+    status = cudaFree(pMem_conformations2);
+    RTERROR(status, "cudaFree: error freeing pMem_conformations2");
+    status = cudaFree(pMem_energies1);
+    RTERROR(status, "cudaFree: error freeing pMem_energies1");    
+    status = cudaFree(pMem_energies2);
+    RTERROR(status, "cudaFree: error freeing pMem_energies2"); 
+    status = cudaFree(pMem_evals_of_new_entities);
+    RTERROR(status, "cudaFree: error freeing pMem_evals_of_new_entities");
+    status = cudaFree(pMem_gpu_evals_of_runs);
+    RTERROR(status, "cudaFree: error freeing pMem_gpu_evals_of_runs");
+    status = cudaFree(pMem_prng_states);
+    RTERROR(status, "cudaFree: error freeing pMem_prng_states");
+    cudaDeviceReset();
+    
+    
 	free(cpu_init_populations);
 	free(cpu_energies);
 	free(cpu_result_ligands);
 	free(cpu_prng_seeds);
 	free(cpu_evals_of_runs);
 	free(cpu_ref_ori_angles);
+
+    auto const t4 = std::chrono::steady_clock::now();
+    printf("Shutdown time %fs\n", elapsed_seconds(t3, t4));
 	return 0;
 }
 

--- a/host/src/performdocking.cpp
+++ b/host/src/performdocking.cpp
@@ -875,8 +875,7 @@ filled with clock() */
 			fflush(stdout);
 		}
 	}
-	printf("\n\n");
-    exit(0);
+
 	// ===============================================================================
 	// Modification based on:
 	// http://www.cc.gatech.edu/~vetter/keeneland/tutorial-2012-02-20/08-opencl.pdf

--- a/host/src/processgrid.cpp
+++ b/host/src/processgrid.cpp
@@ -138,7 +138,7 @@ int get_gridinfo(const char* fldfilename, Gridinfo* mygrid)
 	return 0;
 }
 
-int get_gridvalues_f(const Gridinfo* mygrid, float** fgrids, bool cgmaps)
+int get_gridvalues_f(const Gridinfo* mygrid, float* fgrids, bool cgmaps)
 //The function reads the grid point values from the .map files
 //that correspond to the receptor given by the first parameter.
 //It allocates the proper amount of memory and stores the data there,
@@ -151,17 +151,7 @@ int get_gridvalues_f(const Gridinfo* mygrid, float** fgrids, bool cgmaps)
 	char tempstr [128];
 	float* mypoi;
 
-	*fgrids = (float*) malloc(4*(sizeof(float))*(mygrid->num_of_atypes+2)*
-						    (mygrid->size_xyz[0])*
-						    (mygrid->size_xyz[1])*
-						    (mygrid->size_xyz[2]));
-	if (*fgrids == NULL)
-	{
-		printf("Error: not enough memory!\n");
-		return 1;
-	}
-
-	mypoi = *fgrids;
+	mypoi = fgrids;
 
 	for (t=0; t < mygrid->num_of_atypes+2; t++)
 	{

--- a/host/src/processgrid.cpp
+++ b/host/src/processgrid.cpp
@@ -25,6 +25,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
 #include "processgrid.h"
 
 int get_gridinfo(const char* fldfilename, Gridinfo* mygrid)

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -63,13 +63,14 @@ int init_liganddata(const char* ligfilename,
 				fseek(fp, 25, SEEK_CUR);
 			else
 				fseek(fp, 27, SEEK_CUR);
-			fscanf(fp, "%*f");		//skipping fields
-			fscanf(fp, "%*f");
-			fscanf(fp, "%*f");
-			fscanf(fp, "%*s");
-			fscanf(fp, "%*s");
-			fscanf(fp, "%*f");
-			fscanf(fp, "%s", tempstr);	//reading atom type
+                        int result;
+			result = fscanf(fp, "%*f");		//skipping fields
+			result = fscanf(fp, "%*f");
+			result = fscanf(fp, "%*f");
+			result = fscanf(fp, "%*s");
+			result = fscanf(fp, "%*s");
+			result = fscanf(fp, "%*f");
+			result = fscanf(fp, "%s", tempstr);	//reading atom type
 
 			tempstr[3] = '\0';	//just to be sure strcpy wont fail even if something is wrong with position
 

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 */
 
+
+
 // Output showing the CG-G0 virtual bonds and pairs
 // #define CG_G0_INFO
 

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -863,7 +863,7 @@ int get_VWpars(Liganddata* myligand, const double AD4_coeff_vdW, const double AD
 	return 0;
 }
 
-void get_moving_and_unit_vectors(Liganddata* myligand)
+int get_moving_and_unit_vectors(Liganddata* myligand)
 //The function calculates and fills the
 //rotbonds_moving_vectors and rotbonds_unit_vectors fields of the myligand parameter.
 {
@@ -891,6 +891,12 @@ void get_moving_and_unit_vectors(Liganddata* myligand)
 
 		//normalize unitvector
 		dist = distance(pointA, pointB);
+
+		if (dist==0.0){
+			printf("Error: Two atoms have the same XYZ coordinates!\n");
+                	return 1;
+		}
+
 		for (i=0; i<3; i++) //capturing coordinates of the two atoms
 		{
 			unitvec [i] = unitvec [i]/dist;
@@ -910,7 +916,7 @@ void get_moving_and_unit_vectors(Liganddata* myligand)
 			myligand->rotbonds_unit_vectors [rotb_id][i] = unitvec [i];
 		}
 	}
-
+	return 0;
 }
 
 int get_liganddata(const char* ligfilename, Liganddata* myligand, const double AD4_coeff_vdW, const double AD4_coeff_hb)
@@ -1068,7 +1074,8 @@ int get_liganddata(const char* ligfilename, Liganddata* myligand, const double A
 	if (get_VWpars(myligand, AD4_coeff_vdW, AD4_coeff_hb) == 1)
 		return 1;
 
-	get_moving_and_unit_vectors(myligand);
+	if (get_moving_and_unit_vectors(myligand) == 1)
+                return 1;
 
 	return 0;
 }

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -150,7 +150,7 @@ void write_basic_info_dlg(FILE* fp, const Liganddata* ligand_ref, const Dockpars
 	char temp_filename [128];
 	int i;
 
-	fprintf(fp, "AutoDock-GPU version: %s\n\n", VERSION);
+	fprintf(fp, "AutoDock-GPU version: %s\n\n", "sd-tsri-195-g25d913d6d79b52a64961714de0f358e0ecc7d4a4");
 
 	fprintf(fp, "**********************************************************\n");
 	fprintf(fp, "**    AutoDock-GPU AUTODOCKTOOLS-COMPATIBLE DLG FILE    **\n");
@@ -530,7 +530,7 @@ void cluster_analysis(Ligandresult myresults [], int num_of_runs, char* report_f
 
 void clusanal_gendlg(Ligandresult myresults [], int num_of_runs, const Liganddata* ligand_ref,
 					 const Dockpars* mypars, const Gridinfo* mygrid, const int* argc, char** argv, const double docking_avg_runtime,
-					 const double program_runtime, unsigned long generations_used, unsigned long evals_performed)
+					 unsigned long generations_used, unsigned long evals_performed)
 //The function performs ranked cluster analisys similar to that of AutoDock and creates a file with report_file_name name, the result
 //will be written to it.
 {

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -572,8 +572,8 @@ void clusanal_gendlg(Ligandresult myresults [], int num_of_runs, const Liganddat
 
 	fprintf(fp, "           COUNTER STATES           \n");
 	fprintf(fp, "___________________________________\n\n");
-	fprintf(fp, "Number of energy evaluations performed:    %d\n", evals_performed);
-	fprintf(fp, "Number of generations used:                %d\n", generations_used);
+	fprintf(fp, "Number of energy evaluations performed:    %lu\n", evals_performed);
+	fprintf(fp, "Number of generations used:                %lu\n", generations_used);
 	fprintf(fp, "\n\n");
 
 	//writing input pdbqt file

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -25,6 +25,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
 #include "processresult.h"
 
 

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -1,0 +1,138 @@
+/*
+
+AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian Genetic Algorithm
+Copyright (C) 2017 TU Darmstadt, Embedded Systems and Applications Group, Germany. All rights reserved.
+For some of the code, Copyright (C) 2019 Computational Structural Biology Center, the Scripps Research Institute.
+
+AutoDock is a Trade Mark of the Scripps Research Institute.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "filelist.hpp"
+#include "processgrid.h"
+#include "processligand.h"
+#include "getparameters.h"
+#include "setup.hpp"
+
+int setup(Gridinfo&            mygrid,
+	  std::vector<float>& floatgrids,
+	  Dockpars&            mypars,
+	  Liganddata&          myligand_init,
+	  Liganddata&          myxrayligand,
+	  FileList&            filelist,
+	  int i_file,
+	  int argc, char* argv[])
+{
+	//------------------------------------------------------------
+	// Capturing names of grid parameter file and ligand pdbqt file
+	//------------------------------------------------------------
+
+	if(filelist.used){
+		strcpy(mypars.fldfile, filelist.fld_files[i_file].c_str());
+		strcpy(mypars.ligandfile, filelist.ligand_files[i_file].c_str());
+	}
+
+	// Filling the filename and coeffs fields of mypars according to command line arguments
+	if (get_filenames_and_ADcoeffs(&argc, argv, &mypars, filelist.used) != 0)
+		{printf("\n\nError in get_filenames_and_ADcoeffs, stopped job."); return 1;}
+
+	//------------------------------------------------------------
+	// Testing command line arguments for cgmaps parameter
+	// since we need it at grid creation time
+	//------------------------------------------------------------
+	mypars.cgmaps = 0; // default is 0 (use one maps for every CGx or Gx atom types, respectively)
+	for (unsigned int i=1; i<argc-1; i+=2)
+	{
+		// ----------------------------------
+		//Argument: Use individual maps for CG-G0 instead of the same one
+		if (strcmp("-cgmaps", argv [i]) == 0)
+		{
+			int tempint;
+			sscanf(argv [i+1], "%d", &tempint);
+			if (tempint == 0)
+				mypars.cgmaps = 0;
+			else
+				mypars.cgmaps = 1;
+		}
+	}
+
+	//------------------------------------------------------------
+	// Processing receptor and ligand files
+	//------------------------------------------------------------
+
+	// Filling mygrid according to the gpf file
+	if (get_gridinfo(mypars.fldfile, &mygrid) != 0)
+		{printf("\n\nError in get_gridinfo, stopped job."); return 1;}
+
+	// Filling the atom types filed of myligand according to the grid types
+	if (init_liganddata(mypars.ligandfile, &myligand_init, &mygrid, mypars.cgmaps) != 0)
+		{printf("\n\nError in init_liganddata, stopped job."); return 1;}
+
+	// Filling myligand according to the pdbqt file
+	if (get_liganddata(mypars.ligandfile, &myligand_init, mypars.coeffs.AD4_coeff_vdW, mypars.coeffs.AD4_coeff_hb) != 0)
+		{printf("\n\nError in get_liganddata, stopped job."); return 1;}
+
+	// Resize grid
+	floatgrids.resize(4*(mygrid.num_of_atypes+2)*mygrid.size_xyz[0]*mygrid.size_xyz[1]*mygrid.size_xyz[2]);
+
+	//Reading the grid files and storing values in the memory region pointed by floatgrids
+	if (get_gridvalues_f(&mygrid, floatgrids.data(), mypars.cgmaps) != 0)
+		{printf("\n\nError in get_gridvalues_f, stopped job."); return 1;}
+
+	//------------------------------------------------------------
+	// Capturing algorithm parameters (command line args)
+	//------------------------------------------------------------
+	get_commandpars(&argc, argv, &(mygrid.spacing), &mypars);
+
+	if (filelist.resnames.size()>0){ // Overwrite resname with specified filename if specified in file list
+		strcpy(mypars.resname, filelist.resnames[i_file].c_str());
+	} else if (filelist.used) { // otherwise add the index to existing name distinguish the files if multiple
+		std::string if_str = std::to_string(i_file);
+		strcat(mypars.resname, if_str.c_str());
+	}
+
+	Gridinfo mydummygrid;
+	// if -lxrayfile provided, then read xray ligand data
+	if (mypars.given_xrayligandfile == true) {
+		if (init_liganddata(mypars.xrayligandfile, &myxrayligand, &mydummygrid, mypars.cgmaps) != 0)
+			{printf("\n\nError in init_liganddata, stopped job."); return 1;}
+
+		if (get_liganddata(mypars.xrayligandfile, &myxrayligand, mypars.coeffs.AD4_coeff_vdW, mypars.coeffs.AD4_coeff_hb) != 0)
+			{printf("\n\nError in get_liganddata, stopped job."); return 1;}
+	}
+
+	//------------------------------------------------------------
+	// Calculating energies of reference ligand if required
+	//------------------------------------------------------------
+	if (mypars.reflig_en_reqired == 1) {
+		print_ref_lig_energies_f(myligand_init,
+					 mypars.smooth,
+					 mygrid,
+					 floatgrids.data(),
+					 mypars.coeffs.scaled_AD4_coeff_elec,
+					 mypars.coeffs.AD4_coeff_desolv,
+					 mypars.qasp);
+	}
+
+	return 0;
+}

--- a/preamble_license_lgpl
+++ b/preamble_license_lgpl
@@ -1,0 +1,23 @@
+/*
+
+AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian Genetic Algorithm
+Copyright (C) 2017 TU Darmstadt, Embedded Systems and Applications Group, Germany. All rights reserved.
+For some of the code, Copyright (C) 2019 Computational Structural Biology Center, the Scripps Research Institute.
+
+AutoDock is a Trade Mark of the Scripps Research Institute.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/

--- a/wrapcl/inc/BufferObjects.h
+++ b/wrapcl/inc/BufferObjects.h
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef BUFFER_OBJECTS_H
 #define BUFFER_OBJECTS_H
 

--- a/wrapcl/inc/CommandQueues.h
+++ b/wrapcl/inc/CommandQueues.h
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef COMMAND_QUEUES_H
 #define COMMAND_QUEUES_H
 

--- a/wrapcl/inc/Contexts.h
+++ b/wrapcl/inc/Contexts.h
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef CONTEXTS_H
 #define CONTEXTS_H
 

--- a/wrapcl/inc/Devices.h
+++ b/wrapcl/inc/Devices.h
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef DEVICES_H
 #define DEVICES_H
 

--- a/wrapcl/inc/ImportBinary.h
+++ b/wrapcl/inc/ImportBinary.h
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef IMPORT_BINARY_H
 #define IMPORT_BINARY_H
 

--- a/wrapcl/inc/ImportSource.h
+++ b/wrapcl/inc/ImportSource.h
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef IMPORT_SOURCE_H
 #define IMPORT_SOURCE_H
 

--- a/wrapcl/inc/Kernels.h
+++ b/wrapcl/inc/Kernels.h
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef KERNELS_H
 #define KERNELS_H
 

--- a/wrapcl/inc/Platforms.h
+++ b/wrapcl/inc/Platforms.h
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef PLATFORMS_H
 #define PLATFORMS_H
 

--- a/wrapcl/inc/Programs.h
+++ b/wrapcl/inc/Programs.h
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef PROGRAMS_H
 #define PROGRAMS_H
 

--- a/wrapcl/inc/commonMacros.h
+++ b/wrapcl/inc/commonMacros.h
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef COMMON_MACROS_H
 #define COMMON_MACROS_H
 

--- a/wrapcl/inc/listAttributes.h
+++ b/wrapcl/inc/listAttributes.h
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef LIST_ATTRIBUTES_H
 #define LIST_ATTRIBUTES_H
 

--- a/wrapcl/src/BufferObjects.cpp
+++ b/wrapcl/src/BufferObjects.cpp
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include "BufferObjects.h"
 
 int mallocBufferObject(cl_context   context,

--- a/wrapcl/src/CommandQueues.cpp
+++ b/wrapcl/src/CommandQueues.cpp
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include "CommandQueues.h"
 
 int createCommandQueue(cl_context 	 context,

--- a/wrapcl/src/Contexts.cpp
+++ b/wrapcl/src/Contexts.cpp
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include "Contexts.h"
 
 int createContext(

--- a/wrapcl/src/Devices.cpp
+++ b/wrapcl/src/Devices.cpp
@@ -59,7 +59,7 @@ int getDevices(cl_platform_id   platform_id, cl_uint  platformCount,
 	fflush(stdout);
 #endif
 	if (err != CL_SUCCESS){
-		printf("Error: clGetDevices(): %d\n", err);
+		printf("Error: clGetDeviceIDs(): %d\n", err);
 		fflush(stdout);
 		return EXIT_FAILURE;
   }

--- a/wrapcl/src/Devices.cpp
+++ b/wrapcl/src/Devices.cpp
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include "Devices.h"
 
 int getDevices(cl_platform_id   platform_id, cl_uint  platformCount,

--- a/wrapcl/src/ImportBinary.cpp
+++ b/wrapcl/src/ImportBinary.cpp
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include "ImportBinary.h"
 
 int load_file_to_memory(const char *filename, char **result)

--- a/wrapcl/src/ImportSource.cpp
+++ b/wrapcl/src/ImportSource.cpp
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include "ImportSource.h"
 
 /* convert the kernel file into a string */

--- a/wrapcl/src/Kernels.cpp
+++ b/wrapcl/src/Kernels.cpp
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include "Kernels.h"
 
 

--- a/wrapcl/src/Platforms.cpp
+++ b/wrapcl/src/Platforms.cpp
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include "Platforms.h"
 
 int getPlatforms(cl_platform_id** platform_id, cl_uint* platformCount){

--- a/wrapcl/src/Programs.cpp
+++ b/wrapcl/src/Programs.cpp
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include "Programs.h"
 
 #ifdef PROGRAM_INFO_DISPLAY

--- a/wrapcl/src/listAttributes.cpp
+++ b/wrapcl/src/listAttributes.cpp
@@ -25,6 +25,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include "listAttributes.h"
 
   /*extern*/


### PR DESCRIPTION
Quick fix to ligands that were converted improperly and have multiple atoms in the same location: just skip those ligands.