### PR TITLE
Make sure all files opened with fopen are closed

### DIFF
--- a/host/src/processgrid.cpp
+++ b/host/src/processgrid.cpp
@@ -81,6 +81,7 @@ int get_gridinfo(const char* fldfilename, Gridinfo* mygrid)
 			if (mygrid->spacing > 1)
 			{
 				printf("Error: grid spacing is too big!\n");
+				fclose(fp);
 				return 1;
 			}
 		}
@@ -98,6 +99,7 @@ int get_gridinfo(const char* fldfilename, Gridinfo* mygrid)
 			if ((mygrid->size_xyz [0] > MAX_NUM_GRIDPOINTS) || (mygrid->size_xyz [1] > MAX_NUM_GRIDPOINTS) || (mygrid->size_xyz [2] > MAX_NUM_GRIDPOINTS))
 			{
 				printf("Error: each dimension of the grid must be below %i.\n", MAX_NUM_GRIDPOINTS);
+				fclose(fp);
 				return 1;
 			}
 		}
@@ -203,6 +205,7 @@ int get_gridvalues_f(const Gridinfo* mygrid, float* fgrids, bool cgmaps)
 					if(y>0 && z>0) *(mypoi-4*(g2+g1)+3) = *mypoi;
 					mypoi+=4;
 				}
+		fclose(fp);
 	}
 
 	return 0;

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -89,6 +89,7 @@ int init_liganddata(const char* ligfilename,
 				if (num_of_atypes >= MAX_NUM_OF_ATYPES)
 				{
 					printf("Error: too many types of ligand atoms!\n");
+					fclose(fp);
 					return 1;
 				}
 
@@ -97,6 +98,8 @@ int init_liganddata(const char* ligfilename,
 			}
 		}
 	}
+
+	fclose(fp);
 
 	//copying field to ligand and grid data
 	myligand->num_of_atypes = num_of_atypes;
@@ -955,6 +958,7 @@ int get_liganddata(const char* ligfilename, Liganddata* myligand, const double A
 			{
 				printf("Error: ligand consists of too many atoms'\n");
 				printf("Maximal allowed number of atoms is %d!\n", MAX_NUM_OF_ATOMS);
+				fclose(fp);
 				return 1;
 			}
 			if ((strcmp(tempstr, "HETATM") == 0))	//seeking to the first coordinate value
@@ -968,8 +972,10 @@ int get_liganddata(const char* ligfilename, Liganddata* myligand, const double A
 			fscanf(fp, "%s", tempstr);
 			fscanf(fp, "%lf", &(myligand->atom_idxyzq [atom_counter][4]));	//reading charge
 			fscanf(fp, "%s", tempstr);	//reading atom type
-			if (set_liganddata_typeid(myligand, atom_counter, tempstr) != 0)	//the function sets the type index
+			if (set_liganddata_typeid(myligand, atom_counter, tempstr) != 0){	//the function sets the type index
+				fclose(fp);
 				return 1;
+			}
 			atom_counter++;
 		}
 	}
@@ -1052,6 +1058,8 @@ int get_liganddata(const char* ligfilename, Liganddata* myligand, const double A
 			current_rigid_struct_id--;	//probably unnecessary since there is a new branch after every endbranch...
 		}
 	}
+
+	fclose(fp);
 
 	myligand->num_of_rotbonds = branch_counter;
 


### PR DESCRIPTION
Resolve file reading issue where too many files are open by making sure that files are closed both normally and when an error is encountered.